### PR TITLE
Fix failing tests on Windows

### DIFF
--- a/GodotEnv.Tests/src/common/clients/FileClientTest.cs
+++ b/GodotEnv.Tests/src/common/clients/FileClientTest.cs
@@ -379,7 +379,8 @@ public class FileClientTest {
       fs, computer.Object, new Mock<IProcessRunner>().Object
     );
 
-    client.GetRootedPath("a/b", "/").ShouldBe("/a/b");
+    var expectedBasePath = fs.Path.GetFullPath(fs.Path.Combine("/", "/a/b"));
+    client.GetRootedPath("a/b", "/").ShouldBe(expectedBasePath);
     client.GetRootedPath("/a/b/c", "/").ShouldBe("/a/b/c");
   }
 

--- a/GodotEnv.Tests/src/common/utilities/LogTest.cs
+++ b/GodotEnv.Tests/src/common/utilities/LogTest.cs
@@ -4,61 +4,60 @@
 namespace Chickensoft.GodotEnv.Tests;
 
 using System;
-using Chickensoft.GodotEnv.Common.Utilities;
-using CliFx.Infrastructure;
+using Common.Utilities;
 using Moq;
 using Shouldly;
 using Xunit;
 
-public class LogTest {
+public sealed class LogTest : IDisposable {
+
+  private readonly OutputTestFakeInMemoryConsole _console = new ();
+
+  public void Dispose() => _console.Dispose();
+
   [Fact]
   public void Prints() {
-    FakeInMemoryConsole console = new();
-    Log log = new(console);
+    Log log = new(_console);
 
     log.Print("Hello, world!");
 
-    console.ReadOutputString().ShouldBe("Hello, world!\n");
+    _console.ReadOutputString().ShouldBe("Hello, world!\n");
   }
 
   [Fact]
   public void PrintsInfo() {
-    FakeInMemoryConsole console = new();
-    Log log = new(console);
+    Log log = new(_console);
 
     log.Info("Hello, world!");
 
-    console.ReadOutputString().ShouldBe("Hello, world!\n");
+    _console.ReadOutputString().ShouldBe("Hello, world!\n");
   }
 
   [Fact]
   public void PrintsWarning() {
-    FakeInMemoryConsole console = new();
-    Log log = new(console);
+    Log log = new(_console);
 
     log.Warn("Hello, world!");
 
-    console.ReadOutputString().ShouldBe("Hello, world!\n");
+    _console.ReadOutputString().ShouldBe("Hello, world!\n");
   }
 
   [Fact]
   public void PrintsErr() {
-    FakeInMemoryConsole console = new();
-    Log log = new(console);
+    Log log = new(_console);
 
     log.Err("Hello, world!");
 
-    console.ReadOutputString().ShouldBe("Hello, world!\n");
+    _console.ReadOutputString().ShouldBe("Hello, world!\n");
   }
 
   [Fact]
   public void PrintsSuccess() {
-    FakeInMemoryConsole console = new();
-    Log log = new(console);
+    Log log = new(_console);
 
     log.Success("Hello, world!");
 
-    console.ReadOutputString().ShouldBe("Hello, world!\n\n");
+    _console.ReadOutputString().ShouldBe("Hello, world!\n\n");
   }
 
   [Fact]
@@ -69,8 +68,7 @@ public class LogTest {
 
   [Fact]
   public void OutputsCorrectStyleChanges() {
-    FakeInMemoryConsole console = new();
-    Log log = new(console);
+    Log log = new(_console);
 
     log.Print("A");
     log.Print("");
@@ -86,7 +84,7 @@ public class LogTest {
     log.Err("E");
     log.Success("F");
 
-    console.ReadOutputString().ShouldBe("A\n\nB\n\nC\nD\n\nE\nF\n\n");
+    _console.ReadOutputString().ShouldBe("A\n\nB\n\nC\nD\n\nE\nF\n\n");
 
     var debugLog = log.ToString();
 
@@ -109,8 +107,7 @@ public class LogTest {
 
   [Fact]
   public void OutputsNull() {
-    FakeInMemoryConsole console = new();
-    Log log = new(console);
+    Log log = new(_console);
 
     log.Print(null);
     log.Info(null);
@@ -118,25 +115,24 @@ public class LogTest {
     log.Err(null);
     log.Success(null);
 
-    console.ReadOutputString().Trim().ShouldBe("");
+    _console.ReadOutputString().Trim().ShouldBe("");
     log.ToString().Trim().ShouldBe("");
   }
 
   [Fact]
   public void OutputsObject() {
-    FakeInMemoryConsole console = new();
-    Log log = new(console);
+    Log log = new(_console);
 
     log.Print(new { Hello = "world" });
 
-    console.ReadOutputString().ShouldBe("{ Hello = world }\n");
+    _console.ReadOutputString().ShouldBe("{ Hello = world }\n");
   }
 
   [Fact]
   public void ReportableEventInvokesCallback() {
     var log = new Mock<ILog>();
     var called = false;
-    var @event = new ReportableEvent((log) => called = true);
+    var @event = new ReportableEvent((_) => called = true);
 
     @event.Report(log.Object);
 

--- a/GodotEnv.Tests/src/common/utilities/ProcessRunnerTest.cs
+++ b/GodotEnv.Tests/src/common/utilities/ProcessRunnerTest.cs
@@ -3,14 +3,25 @@ using System;
 using System.Threading.Tasks;
 using Chickensoft.GodotEnv.Common.Utilities;
 using Shouldly;
-using Xunit;
 
 public class ProcessRunnerTest {
-  [Fact]
-  public async Task RunsProcess() {
+  [PlatformFact(TestPlatform.Windows)]
+  public async Task RunsProcessOnWindows() {
     var runner = new ProcessRunner();
     var result = await runner.Run(
-      Environment.CurrentDirectory, "echo", new string[] { "hello" }
+      Environment.CurrentDirectory, "cmd", new[] { "/c echo \"hello\"" }
+    );
+    result.ExitCode.ShouldBe(0);
+    result.Succeeded.ShouldBe(true);
+    result.StandardOutput.ShouldBe($"""\"hello\""{Environment.NewLine}""");
+    result.StandardError.ShouldBe("");
+  }
+
+  [PlatformFact(TestPlatform.MacLinux)]
+  public async Task RunsProcessOnMacLinux() {
+    var runner = new ProcessRunner();
+    var result = await runner.Run(
+      Environment.CurrentDirectory, "echo", new[] { "hello" }
     );
     result.ExitCode.ShouldBe(0);
     result.Succeeded.ShouldBe(true);

--- a/GodotEnv.Tests/test_utils/OutputTestFakeInMemoryConsole.cs
+++ b/GodotEnv.Tests/test_utils/OutputTestFakeInMemoryConsole.cs
@@ -1,0 +1,9 @@
+﻿namespace Chickensoft.GodotEnv.Tests;
+
+using CliFx.Infrastructure;
+
+public class OutputTestFakeInMemoryConsole : FakeInMemoryConsole {
+
+  // Used for testing console output to ensure consistent line endings across platforms.
+  public new string ReadOutputString() => Output.Encoding.GetString(ReadOutputBytes()).ReplaceLineEndings("\n");
+}

--- a/GodotEnv.Tests/test_utils/PlatformFact.cs
+++ b/GodotEnv.Tests/test_utils/PlatformFact.cs
@@ -1,0 +1,21 @@
+﻿namespace Chickensoft.GodotEnv.Tests;
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+public enum TestPlatform {
+  Windows,
+  MacLinux,
+}
+
+public sealed class PlatformFact : FactAttribute {
+  public PlatformFact(TestPlatform testPlatform) {
+    Skip = testPlatform switch {
+      TestPlatform.Windows when !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) =>
+        $"Skipped Windows specific test",
+      TestPlatform.MacLinux when RuntimeInformation.IsOSPlatform(OSPlatform.Windows) =>
+        $"Skipped Mac/Linux specific test",
+      _ => Skip
+    };
+  }
+}


### PR DESCRIPTION
Closes #17 

Introduces:
* New `OutputTestFakeInMemoryConsole` that makes new line endings consistent for console output tests (using `\n`).
* New `PlatformFact` that allows for platform specific tests (currently allows for specifying Windows or macOS/Linux).