### PR TITLE
Add remote versions option to list command

### DIFF
--- a/GodotEnv.Tests/src/common/utilities/LogTest.cs
+++ b/GodotEnv.Tests/src/common/utilities/LogTest.cs
@@ -101,7 +101,7 @@ public sealed class LogTest : IDisposable {
         [/style][style fg="green"]F
 
         [/style]
-        """.ReplaceLineEndings()
+        """
     );
   }
 

--- a/GodotEnv.Tests/src/features/godot/commands/GodotListCommandTest.cs
+++ b/GodotEnv.Tests/src/features/godot/commands/GodotListCommandTest.cs
@@ -1,0 +1,72 @@
+﻿namespace Chickensoft.GodotEnv.Tests.features.godot.commands;
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using Shouldly;
+using CliFx.Infrastructure;
+
+using Common.Models;
+using Common.Utilities;
+using Features.Godot.Domain;
+using Features.Addons.Commands;
+
+public sealed class GodotListCommandTest : IDisposable {
+
+  private readonly Mock<IExecutionContext> _context;
+  private readonly Mock<IGodotContext> _godotContext;
+  private readonly Mock<IGodotRepository> _godotRepo;
+  private readonly FakeInMemoryConsole _console;
+  private readonly Log _log;
+
+  public GodotListCommandTest() {
+    _context = new Mock<IExecutionContext>();
+    _godotContext = new Mock<IGodotContext>();
+    _godotRepo = new Mock<IGodotRepository>();
+    _console = new FakeInMemoryConsole();
+    _log = new Log(_console);
+
+    _godotContext.SetupGet(c => c.GodotRepo).Returns(_godotRepo.Object);
+    _context.SetupGet(context => context.Godot).Returns(_godotContext.Object);
+    _context.Setup(context => context.CreateLog(_console)).Returns(_log);
+  }
+
+  public void Dispose() => _console.Dispose();
+
+  [Fact]
+  public async Task Executes() {
+    var testVersions = new List<string> { "3.2.3", "4.0.1" };
+    _godotRepo.Setup(r => r.GetRemoteVersionsList()).ReturnsAsync(testVersions);
+
+    var listCommand = new GodotListCommand(_context.Object) { ListRemoteAvailable = true };
+    await listCommand.ExecuteAsync(_console);
+
+    _godotRepo.Verify(r => r.GetRemoteVersionsList());
+    _log.ToString().ShouldBe(
+      """
+        Retrieving available Godot versions...
+        3.2.3
+        4.0.1
+
+        """);
+  }
+
+  [Fact]
+  public async Task FailsGracefullyOnHttpException() {
+    _godotRepo.Setup(r => r.GetRemoteVersionsList()).Throws<HttpRequestException>();
+
+    var listCommand = new GodotListCommand(_context.Object) { ListRemoteAvailable = true };
+    await listCommand.ExecuteAsync(_console);
+
+    _godotRepo.Verify(r => r.GetRemoteVersionsList());
+    _log.ToString().ShouldBe(
+      """
+        Retrieving available Godot versions...
+        Unable to reach remote Godot versions list.
+
+        """);
+  }
+}

--- a/GodotEnv/src/common/clients/NetworkClient.cs
+++ b/GodotEnv/src/common/clients/NetworkClient.cs
@@ -1,6 +1,7 @@
 namespace Chickensoft.GodotEnv.Common.Clients;
 
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using CliFx.Exceptions;
@@ -17,11 +18,15 @@ public interface INetworkClient {
     IProgress<DownloadProgressChangedEventArgs> progress,
     CancellationToken token
   );
+
+  public Task<HttpResponseMessage> WebRequestGetAsync(string url);
 }
 
 public class NetworkClient : INetworkClient {
   public IDownloadService DownloadService { get; }
   public DownloadConfiguration DownloadConfiguration { get; }
+
+  private static HttpClient? _client;
 
   public NetworkClient(
     IDownloadService downloadService,
@@ -29,6 +34,12 @@ public class NetworkClient : INetworkClient {
   ) {
     DownloadService = downloadService;
     DownloadConfiguration = downloadConfiguration;
+  }
+
+  public async Task<HttpResponseMessage> WebRequestGetAsync(string url) {
+    _client ??= new HttpClient();
+
+    return await _client.GetAsync(url);
   }
 
   public async Task DownloadFileAsync(

--- a/GodotEnv/src/features/godot/commands/GodotListCommand.cs
+++ b/GodotEnv/src/features/godot/commands/GodotListCommand.cs
@@ -1,28 +1,56 @@
 namespace Chickensoft.GodotEnv.Features.Addons.Commands;
 
+using System.Net.Http;
 using System.Threading.Tasks;
 using Chickensoft.GodotEnv.Common.Models;
 using CliFx;
 using CliFx.Attributes;
 using CliFx.Infrastructure;
+using Common.Utilities;
+using Godot.Domain;
 
 [Command("godot list", Description = "List installed Godot versions.")]
 public class GodotListCommand : ICommand, ICliCommand {
   public IExecutionContext ExecutionContext { get; set; } = default!;
 
+  [CommandOption("remote", 'r',
+    Description = "Specify to list all available versions of Godot")]
+  public bool ListRemoteAvailable { get; set; }
+
   public GodotListCommand(IExecutionContext context) {
     ExecutionContext = context;
+  }
+
+  private static void ListLocalVersions(ILog log, IGodotRepository godotRepo) {
+    foreach (var installation in godotRepo.GetInstallationsList()) {
+      var activeTag = installation.IsActiveVersion ? " *" : "";
+      log.Print(installation.VersionName + activeTag);
+    }
+  }
+
+  private static async Task ListRemoteVersions(ILog log, IGodotRepository godotRepo) {
+    log.Print("Retrieving available Godot versions...");
+
+    try {
+      var remoteVersions = await godotRepo.GetRemoteVersionsList();
+      foreach (var version in remoteVersions) {
+        log.Print(version);
+      }
+    }
+    catch (HttpRequestException e) {
+      log.Print("Unable to reach remote Godot versions list.");
+    }
   }
 
   public async ValueTask ExecuteAsync(IConsole console) {
     var log = ExecutionContext.CreateLog(console);
     var godotRepo = ExecutionContext.Godot.GodotRepo;
 
-    foreach (
-      var installation in godotRepo.GetInstallationsList()
-    ) {
-      var activeTag = installation.IsActiveVersion ? " *" : "";
-      log.Print(installation.VersionName + activeTag);
+    if (ListRemoteAvailable) {
+      await ListRemoteVersions(log, godotRepo);
+    }
+    else {
+      ListLocalVersions(log, godotRepo);
     }
 
     await Task.CompletedTask;


### PR DESCRIPTION
This PR introduces:

* A `WebRequestGetAsync` method that simply wraps `HttpClient.GetAsync()`.
* A new `-remote` /  `-r` option for the `list` command to get remote versions available, following a convention others might be familiar with from `nvm`.
* Automated tests added for this new option

Closes #12 