### PR TITLE
Switch to GitHub Downloads

### DIFF
--- a/GodotEnv.Tests/src/features/godot/models/GodotEnvironmentTest.cs
+++ b/GodotEnv.Tests/src/features/godot/models/GodotEnvironmentTest.cs
@@ -1,0 +1,84 @@
+namespace Chickensoft.GodotEnv.Tests.features.godot.models;
+
+using Common.Clients;
+using Common.Utilities;
+using Features.Godot.Models;
+using Moq;
+using Shouldly;
+using Xunit;
+
+public class GodotEnvironmentTest {
+  private readonly SemanticVersion version;
+  private readonly Mock<IComputer> computer;
+  private readonly Mock<IFileClient> fileClient;
+
+  public GodotEnvironmentTest() {
+    computer = new Mock<IComputer>();
+    fileClient = new Mock<IFileClient>();
+    version = new SemanticVersion("4", "1", "2", string.Empty);
+  }
+
+  [Fact]
+  public void GetsExpectedMacDownloadUrl() {
+    var platform = new MacOS(fileClient.Object, computer.Object);
+    var downloadUrl = platform.GetDownloadUrl(version, false, false);
+
+    downloadUrl.ShouldBe($"{TestConstants.GODOT_URL_PREFIX}4.1.2-stable/Godot_v4.1.2-stable_macos.universal.zip");
+  }
+
+  [Fact]
+  public void GetsExpectedMacMonoDownloadUrl() {
+    var platform = new MacOS(fileClient.Object, computer.Object);
+    var downloadUrl = platform.GetDownloadUrl(version, true, false);
+
+    downloadUrl.ShouldBe($"{TestConstants.GODOT_URL_PREFIX}4.1.2-stable/Godot_v4.1.2-stable_mono_macos.universal.zip");
+  }
+
+  [Fact]
+  public void GetsExpectedWindowsDownloadUrl() {
+    var platform = new Windows(fileClient.Object, computer.Object);
+    var downloadUrl = platform.GetDownloadUrl(version, false, false);
+
+    downloadUrl.ShouldBe($"{TestConstants.GODOT_URL_PREFIX}4.1.2-stable/Godot_v4.1.2-stable_win64.exe.zip");
+  }
+
+  [Fact]
+  public void GetsExpectedWindowsMonoDownloadUrl() {
+    var platform = new Windows(fileClient.Object, computer.Object);
+    var downloadUrl = platform.GetDownloadUrl(version, true, false);
+
+    downloadUrl.ShouldBe($"{TestConstants.GODOT_URL_PREFIX}4.1.2-stable/Godot_v4.1.2-stable_mono_win64.zip");
+  }
+
+  [Fact]
+  public void GetsExpectedLinuxDownloadUrl() {
+    var platform = new Linux(fileClient.Object, computer.Object);
+    var downloadUrl = platform.GetDownloadUrl(version, false, false);
+
+    downloadUrl.ShouldBe($"{TestConstants.GODOT_URL_PREFIX}4.1.2-stable/Godot_v4.1.2-stable_linux.x86_64.zip");
+  }
+
+  [Fact]
+  public void GetsExpectedLinuxMonoDownloadUrl() {
+    var platform = new Linux(fileClient.Object, computer.Object);
+    var downloadUrl = platform.GetDownloadUrl(version, true, false);
+
+    downloadUrl.ShouldBe($"{TestConstants.GODOT_URL_PREFIX}4.1.2-stable/Godot_v4.1.2-stable_mono_linux_x86_64.zip");
+  }
+
+  [Fact]
+  public void GetsExpectedTemplatesDownloadUrl() {
+    var platform = new MacOS(fileClient.Object, computer.Object);
+    var downloadUrl = platform.GetDownloadUrl(version, false, true);
+
+    downloadUrl.ShouldBe($"{TestConstants.GODOT_URL_PREFIX}4.1.2-stable/Godot_v4.1.2-stable_export_templates.tpz");
+  }
+
+  [Fact]
+  public void GetsExpectedTemplatesDownloadUrlMono() {
+    var platform = new MacOS(fileClient.Object, computer.Object);
+    var downloadUrl = platform.GetDownloadUrl(version, true, true);
+
+    downloadUrl.ShouldBe($"{TestConstants.GODOT_URL_PREFIX}4.1.2-stable/Godot_v4.1.2-stable_mono_export_templates.tpz");
+  }
+}

--- a/GodotEnv.Tests/src/features/godot/models/GodotEnvironmentTest.cs
+++ b/GodotEnv.Tests/src/features/godot/models/GodotEnvironmentTest.cs
@@ -75,7 +75,7 @@ public class GodotEnvironmentTest {
   }
 
   [Fact]
-  public void GetsExpectedTemplatesDownloadUrlMono() {
+  public void GetsExpectedTemplatesMonoDownloadUrl() {
     var platform = new MacOS(fileClient.Object, computer.Object);
     var downloadUrl = platform.GetDownloadUrl(version, true, true);
 

--- a/GodotEnv.Tests/test_utils/TestConstants.cs
+++ b/GodotEnv.Tests/test_utils/TestConstants.cs
@@ -1,0 +1,5 @@
+namespace Chickensoft.GodotEnv.Tests;
+
+public static class TestConstants {
+  public const string GODOT_URL_PREFIX = "https://github.com/godotengine/godot/releases/download/";
+}

--- a/GodotEnv/src/features/godot/models/GodotEnvironment.cs
+++ b/GodotEnv/src/features/godot/models/GodotEnvironment.cs
@@ -115,7 +115,7 @@ public interface IGodotEnvironment {
 public abstract class GodotEnvironment : IGodotEnvironment {
   public const string GODOT_FILENAME_PREFIX = "Godot_v";
   public const string GODOT_URL_PREFIX =
-    "https://downloads.tuxfamily.org/godotengine/";
+    "https://github.com/godotengine/godot/releases/download/";
 
   /// <summary>
   /// Creates a platform for the given OS.
@@ -253,13 +253,11 @@ public abstract class GodotEnvironment : IGodotEnvironment {
       url += $".{patch}";
     }
 
-    url += "/";
-    if (label != "") {
-      url += $"{label}/";
+    if (label != string.Empty) {
+      url += $"-{label}/";
     }
-
-    if (isDotnetVersion) {
-      url += "mono/";
+    else {
+      url += "-stable/";
     }
 
     // Godot application download url.


### PR DESCRIPTION
This PR changes the Godot download location to GitHub and adds tests that ensure the download URLs for export templates and each platform are generated correctly.

@definitelyokay Before merging, I'd appreciate any edge case scenarios you can think of for the install command that I might have missed. I'll adjust and tests to cover them.