### PR TITLE
Correction of a bug related to logs + improvement of gitignore generation

### DIFF
--- a/GodotEnv/src/common/models/Defaults.cs
+++ b/GodotEnv/src/common/models/Defaults.cs
@@ -133,6 +133,26 @@ public static class Defaults {
   # https://github.com/chickensoft-games/GodotEnv
   #
   # -------------------------------------------------------------------- #
+  
+  # Godot
+  # https://github.com/github/gitignore/blob/main/Godot.gitignore
+  #
+  # Godot 4+ specific ignores
+  .godot/
+  #
+  # Godot-specific ignores
+  .import/
+  export.cfg
+  export_presets.cfg
+  #
+  # Imported translations (automatically generated from CSV files)
+  *.translation
+  #
+  # Mono-specific ignores
+  .mono/
+  data_*/
+  mono_crash.*.json
+  # -------------------------------------------------------------------- #
 
   # GodotEnv Addons
   #
@@ -142,6 +162,8 @@ public static class Defaults {
   # Don't ignore the editorconfig file in the addons directory.
   !{ADDONS_PATH}/.editorconfig
   #
+  # Ignore the addons cache
+  {CACHE_PATH}/*
   # -------------------------------------------------------------------- #
   """;
 }

--- a/GodotEnv/src/features/addons/commands/init/AddonsInitCommand.cs
+++ b/GodotEnv/src/features/addons/commands/init/AddonsInitCommand.cs
@@ -37,6 +37,7 @@ public class AddonsInitCommand : ICommand, ICliCommand {
     log.Success("Done!");
     log.Print("");
     log.Success(path);
+    log.Print("");
 
     await Task.CompletedTask;
   }

--- a/GodotEnv/src/features/addons/domain/AddonsFileRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsFileRepository.cs
@@ -103,10 +103,11 @@ public class AddonsFileRepository : IAddonsFileRepository {
       var addonsIgnoreEntry = $"{Defaults.ADDONS_PATH}/*";
       var addonsEditorConfigExceptionEntry =
         $"!{Defaults.ADDONS_PATH}/.editorconfig";
+      var addonsCacheIgnoreEntry = $"{Defaults.CACHE_PATH}/*";
 
       FileClient.AddLinesToFileIfNotPresent(
         gitIgnoreFilePath,
-        addonsIgnoreEntry, addonsEditorConfigExceptionEntry
+        addonsIgnoreEntry, addonsEditorConfigExceptionEntry, addonsCacheIgnoreEntry
       );
     }
 

--- a/GodotEnv/src/features/godot/commands/cache/GodotCacheClearCommand.cs
+++ b/GodotEnv/src/features/godot/commands/cache/GodotCacheClearCommand.cs
@@ -26,6 +26,7 @@ public class GodotCacheClearCommand : ICommand, ICliCommand {
     log.Print("");
     ExecutionContext.Godot.GodotRepo.ClearCache();
     log.Success("Godot installation cache cleared.");
+    log.Print("");
 
     await Task.CompletedTask;
   }


### PR DESCRIPTION
First of all, thank you for creating GodotEnv ! I've been looking for a dotnet-based package manager for Godot for a while.

I encountered two minor problems during my initial tests.

I had a problem with the colour of the terminal text after calling certain commands (on Windows CMD):

![Capture d'écran 2023-11-16 072920](https://github.com/chickensoft-games/GodotEnv/assets/73344919/a9a86b1c-67c7-4758-a85e-7dde1184c688)
![Capture d'écran 2023-03-07 192426b](https://github.com/chickensoft-games/GodotEnv/assets/73344919/f6ae5051-4c64-422c-b318-d494ae3b6499)

I also noticed that the .addons folder and the files that should be ignored with Godot (https://github.com/github/gitignore/blob/main/Godot.gitignore) were not automatically added to the gitignore.

I created this PR to solve these two minor problems. I've allowed changes in the forked repo, so feel free to edit my changes if you want.