### PR TITLE
Fix a call to git commit

### DIFF
--- a/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
@@ -360,6 +360,12 @@ public class AddonsRepositoryTest {
     );
 
     cli.Runs(addonInstallPath, new ProcessResult(0), "git", "init");
+    cli.Runs(addonInstallPath, new ProcessResult(0), 
+      "git", "config", "--local", "user.email", "godotenv@godotenv.com"
+    );
+    cli.Runs(addonInstallPath, new ProcessResult(0),
+      "git", "config", "--local", "user.name", "GodotEnv"
+    );
     cli.Runs(addonInstallPath, new ProcessResult(0), "git", "add", "-A");
     cli.Runs(
       addonInstallPath, new ProcessResult(0),

--- a/GodotEnv/src/features/addons/domain/AddonsRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsRepository.cs
@@ -214,6 +214,12 @@ public class AddonsRepository(
     // Make a junk repo in the installed addon dir. We use this for change
     // tracking to avoid deleting a modified addon.
     await addonShell.Run("git", "init");
+    await addonShell.Run(
+      "git", "config", "--local", "user.email", "godotenv@godotenv.com"
+    );
+    await addonShell.Run(
+      "git", "config", "--local", "user.name", "GodotEnv"
+    );
     await addonShell.Run("git", "add", "-A");
     await addonShell.Run(
       "git", "commit", "-m", "Initial commit"


### PR DESCRIPTION
I tried to run "godotenv addons install" in a Gitlab CI job, and I got an error related to a "git commit" call in the "addons" folder:
![Capture d'écran 2023-11-18 153501](https://github.com/chickensoft-games/GodotEnv/assets/73344919/9aaa01ef-b02a-4e6a-a419-965a58e18160)

I tried running a "git commit" command in the job and found the reason:
![Capture d'écran 2023-11-18 154410](https://github.com/chickensoft-games/GodotEnv/assets/73344919/247715b9-809b-403e-bab9-baecd6795a34)

This PR includes a fix that sets user.email and user.name with --local to avoid this kind of problem. Feel free to change the arbitrary values I used.