### PR TITLE
Set rollforward to `Major`

### DIFF
--- a/GodotEnv.Tests/Chickensoft.GodotEnv.Tests.csproj
+++ b/GodotEnv.Tests/Chickensoft.GodotEnv.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <RollForward>Major</RollForward>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/GodotEnv/Chickensoft.GodotEnv.csproj
+++ b/GodotEnv/Chickensoft.GodotEnv.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <RollForward>Major</RollForward>
     <LangVersion>preview</LangVersion>
     <PackAsTool>true</PackAsTool>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
Hi 👋 
Changing the rollforward, to be able to run the tool when you only have .net>6 installed.