### PR TITLE
Ignore EOL when comparing strings in tests

### DIFF
--- a/GodotEnv.Tests/src/common/utilities/LogTest.cs
+++ b/GodotEnv.Tests/src/common/utilities/LogTest.cs
@@ -101,8 +101,7 @@ public sealed class LogTest : IDisposable {
         [/style][style fg="green"]F
 
         [/style]
-        """.ReplaceLineEndings()
-    );
+        """, StringCompareShould.IgnoreLineEndings);
   }
 
   [Fact]

--- a/GodotEnv.Tests/src/features/addons/commands/AddonsCommandTest.cs
+++ b/GodotEnv.Tests/src/features/addons/commands/AddonsCommandTest.cs
@@ -32,7 +32,6 @@ public class AddonsCommandTest {
 
 
       [/style]
-      """.ReplaceLineEndings()
-    );
+      """, StringCompareShould.IgnoreLineEndings);
   }
 }

--- a/GodotEnv.Tests/src/features/addons/commands/install/AddonsInstallCommandTest.cs
+++ b/GodotEnv.Tests/src/features/addons/commands/install/AddonsInstallCommandTest.cs
@@ -104,7 +104,7 @@ public class AddonsInstallCommandTest {
     System.InvalidOperationException: Test exception
 
     [/style]
-    """);
+    """, StringCompareShould.IgnoreLineEndings);
   }
 
   [Fact]

--- a/GodotEnv.Tests/src/features/godot/commands/GodotListCommandTest.cs
+++ b/GodotEnv.Tests/src/features/godot/commands/GodotListCommandTest.cs
@@ -4,15 +4,14 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Moq;
-using Xunit;
-using Shouldly;
 using CliFx.Infrastructure;
-
 using Common.Models;
 using Common.Utilities;
-using Features.Godot.Domain;
 using Features.Addons.Commands;
+using Features.Godot.Domain;
+using Moq;
+using Shouldly;
+using Xunit;
 
 public sealed class GodotListCommandTest : IDisposable {
 
@@ -51,7 +50,7 @@ public sealed class GodotListCommandTest : IDisposable {
         3.2.3
         4.0.1
 
-        """);
+        """, StringCompareShould.IgnoreLineEndings);
   }
 
   [Fact]
@@ -67,6 +66,6 @@ public sealed class GodotListCommandTest : IDisposable {
         Retrieving available Godot versions...
         Unable to reach remote Godot versions list.
 
-        """);
+        """, StringCompareShould.IgnoreLineEndings);
   }
 }


### PR DESCRIPTION
Tests were failing on Windows, due to EOL.