### PR TITLE
Fix Invalid Symbolic Link on Windows

### DIFF
--- a/GodotEnv/src/features/godot/models/Windows.cs
+++ b/GodotEnv/src/features/godot/models/Windows.cs
@@ -36,9 +36,9 @@ public class Windows : GodotEnvironment {
       return FileClient.Combine(fsVersionString + "_mono_win64", name);
     }
 
-    // Oddly enough, the non-dotnet folder name ends in ".exe" despite
-    // being a folder.
-    return FileClient.Combine(fsVersionString + "_win64.exe", name);
+    // There is no subfolder for non-dotnet versions.
+    //return FileClient.Combine(fsVersionString + "_win64.exe", name);
+    return name;
   }
 
   public override string GetRelativeGodotSharpPath(


### PR DESCRIPTION
After a bit of research, I found the reason behind issue #35. Mono zip files contain a "Godot_vX.X.X-stable_mono_win64" folder. This is not the case for non-mono zip files (they only contain executables).

You can view the Windows zip files [here](https://github.com/godotengine/godot-builds/) if you want to check their content before merging the PR.