### PR TITLE
fix: create godotenv directory if needed

### DIFF
--- a/GodotEnv.Tests/src/common/clients/FileClientTest.cs
+++ b/GodotEnv.Tests/src/common/clients/FileClientTest.cs
@@ -107,7 +107,10 @@ public class FileClientTest {
 
     client.UserDirectory.ShouldBe(
       Path.TrimEndingDirectorySeparator(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+        Environment.GetFolderPath(
+          Environment.SpecialFolder.UserProfile,
+          Environment.SpecialFolderOption.DoNotVerify
+        )
       )
     );
   }

--- a/GodotEnv/src/Main.cs
+++ b/GodotEnv/src/Main.cs
@@ -256,6 +256,7 @@ public static class GodotEnv {
 /// Custom type activator for CliFx. Creates commands by passing in the
 /// execution context.
 /// </summary>
+/// <param name="context">Execution context.</param>
 public class GodotEnvActivator(IExecutionContext context) : ITypeActivator {
   public IExecutionContext ExecutionContext { get; } = context;
 

--- a/GodotEnv/src/common/clients/FileClient.cs
+++ b/GodotEnv/src/common/clients/FileClient.cs
@@ -320,12 +320,18 @@ public class FileClient : IFileClient {
     IsOSPlatformDefault;
 
   public string UserDirectory => Path.TrimEndingDirectorySeparator(
-    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+    Environment.GetFolderPath(
+      Environment.SpecialFolder.UserProfile,
+      Environment.SpecialFolderOption.DoNotVerify
+    )
   );
 
   public string AppDataDirectory => Files.Path.Combine(
     Files.Path.TrimEndingDirectorySeparator(
-      Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
+      Environment.GetFolderPath(
+        Environment.SpecialFolder.ApplicationData,
+        Environment.SpecialFolderOption.Create
+      )
     ),
     Defaults.BIN_NAME
   );


### PR DESCRIPTION
Fixes #43. The ~/.config directory wasn't getting created if it didn't exist, which means the special folder path comes back null 🙄