### PR TITLE
Fix elevation prompt on Windows

### DIFF
--- a/GodotEnv.Tests/src/features/addons/commands/install/AddonsInstallCommandTest.cs
+++ b/GodotEnv.Tests/src/features/addons/commands/install/AddonsInstallCommandTest.cs
@@ -36,9 +36,12 @@ public class AddonsInstallCommandTest {
     var addonsFileRepo = new Mock<IAddonsFileRepository>();
     var addonGraph = new Mock<IAddonGraph>();
     var addonsRepo = new Mock<IAddonsRepository>();
+    var fileClient = new Mock<IFileClient>();
     var logic = new Mock<AddonsLogic>(
       addonsFileRepo.Object, addonsRepo.Object, addonGraph.Object
     );
+    addonsFileRepo.Setup(ctx => ctx.FileClient).Returns(fileClient.Object);
+    fileClient.Setup(ctx => ctx.OS).Returns(OSType.Linux);
 
     var addonsContext = new Mock<IAddonsContext>();
     addonsContext.Setup(ctx => ctx.AddonsFileRepo)

--- a/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
@@ -46,6 +46,7 @@ public class AddonsRepositoryTest {
     var client = new Mock<IFileClient>();
     var log = new Mock<ILog>();
     var computer = new Mock<IComputer>();
+    var processRunner = new Mock<IProcessRunner>();
     computer
       .Setup(pc => pc.CreateShell(It.IsAny<string>()))
       .Returns((string path) => {
@@ -59,7 +60,7 @@ public class AddonsRepositoryTest {
         );
       });
     var config = new AddonsConfiguration(projectPath, addonsDir, cacheDir);
-    var repo = new AddonsRepository(client.Object, computer.Object, config);
+    var repo = new AddonsRepository(client.Object, computer.Object, config, processRunner.Object);
     return new Subject(
       console: console,
       client: client,

--- a/GodotEnv/src/Main.cs
+++ b/GodotEnv/src/Main.cs
@@ -54,7 +54,8 @@ public static class GodotEnv {
     var addonsRepo = new AddonsRepository(
       fileClient: fileClient,
       computer: computer,
-      config: addonsConfig
+      config: addonsConfig,
+      processRunner: processRunner
     );
     var addonGraph = new AddonGraph();
     var addonsLogic = new AddonsLogic(
@@ -81,7 +82,8 @@ public static class GodotEnv {
       networkClient: networkClient,
       zipClient: zipClient,
       platform: platform,
-      systemEnvironmentVariableClient: systemEnvironmentVariableClient
+      systemEnvironmentVariableClient: systemEnvironmentVariableClient,
+      processRunner: processRunner
     );
 
     var godotContext = new GodotContext(

--- a/GodotEnv/src/common/clients/FileClient.cs
+++ b/GodotEnv/src/common/clients/FileClient.cs
@@ -227,6 +227,12 @@ public interface IFileClient {
       T defaultValue
     ) where T : notnull;
 
+  /// <summary>Check if a file contains a given string.</summary>
+  /// <param name="path">File to read.</param>
+  /// <param name="str">The string to check.</param>
+  /// <returns>A boolean indicating if the file contains the string.</returns>
+  bool FileContains(string path, string str);
+
   /// <summary>Read text lines from a file.</summary>
   /// <param name="path">File to read.</param>
   /// <returns>List of lines.</returns>
@@ -560,6 +566,21 @@ public class FileClient : IFileClient {
     }
     filename = possibleFilenames[0];
     return defaultValue;
+  }
+
+  public bool FileContains(string path, string str) {
+    if (Files.File.Exists(path)) {
+      try {
+        string content = Files.File.ReadAllText(path);
+        return content.Contains(str);
+      }
+      catch (Exception e) {
+        throw new IOException(
+          $"Failed to read file `{path}`", innerException: e
+        );
+      }
+    }
+    return false;
   }
 
   public void WriteJsonFile<T>(string filePath, T data) where T : notnull {

--- a/GodotEnv/src/common/utilities/ProcessRunner.cs
+++ b/GodotEnv/src/common/utilities/ProcessRunner.cs
@@ -1,9 +1,12 @@
 namespace Chickensoft.GodotEnv.Common.Utilities;
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 using System.Text;
 using System.Threading.Tasks;
 using CliWrap;
@@ -57,7 +60,19 @@ public interface IProcessRunner {
     );
 
   /// <summary>
-  /// Attempts to run a shell command as an administrator on Windows.
+  /// Checks if godotenv is elevated on Windows.
+  /// </summary>
+  /// <returns>A boolean indicating if godotenv is elevated</returns>
+  bool IsElevatedOnWindows();
+
+  /// <summary>
+  /// Attempts to restart godotenv with an administrator role on Windows.
+  /// </summary>
+  /// <returns>Process result task.</returns>
+  Task<ProcessResult> ElevateOnWindows();
+
+  /// <summary>
+  /// Attempts to run a shell command that requires an administrator role on Windows.
   /// </summary>
   /// <param name="exe">Process to run (must be in the system shell's path).
   /// </param>
@@ -87,6 +102,59 @@ public class ProcessRunner : IProcessRunner {
     );
   }
 
+  public bool IsElevatedOnWindows() {
+    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+      throw new InvalidOperationException(
+        "IsElevatedOnWindows is only supported on Windows."
+      );
+    }
+
+    return new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
+  }
+
+  public async Task<ProcessResult> ElevateOnWindows() {
+    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+      throw new InvalidOperationException(
+        "ElevateOnWindows is only supported on Windows."
+      );
+    }
+
+    var argsList = Environment.GetCommandLineArgs();
+
+    // Regardless of the call context, the executable returned by GetCommandLineArgs 
+    // is always a dll
+    // It can be executed with the dotnet command
+    string exe = argsList?.FirstOrDefault() ?? string.Empty;
+    if (exe.EndsWith(".exe")) exe = $"\"{exe}\"";
+    if (exe.EndsWith(".dll")) exe = $"dotnet \"{exe}\"";
+
+    string args = string.Join(
+      " ",
+      argsList?.Skip(1)?.Select(
+        arg => (arg?.Contains(' ') ?? false) ? $"\"{arg}\"" : arg
+      )?.ToList() ?? new List<string?>()
+    );
+
+    // Rerun the godotenv command with elevation in a new window
+    Process process = new() {
+      StartInfo = new() {
+        FileName = "cmd",
+        Arguments = $"/s /c \"cd /d \"{Environment.CurrentDirectory}\" & {exe} {args} & pause\"",
+        UseShellExecute = true,
+        Verb = "runas",
+      }
+    };
+
+    process.Start();
+    await process.WaitForExitAsync();
+
+    return new ProcessResult(
+      ExitCode: process.ExitCode,
+      StandardOutput: "",
+      StandardError: ""
+    );
+  }
+
   public async Task<ProcessResult> RunElevatedOnWindows(
     string exe, string args
   ) {
@@ -96,12 +164,23 @@ public class ProcessRunner : IProcessRunner {
       );
     }
 
-    var process = UACHelper.UACHelper.StartElevated(new ProcessStartInfo() {
-      FileName = exe,
-      Arguments = args,
-      UseShellExecute = true,
-      CreateNoWindow = false
-    });
+    // If a debugger is attached, the godotenv command is not elevated globally
+    if (!Debugger.IsAttached && !new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator)) {
+      throw new InvalidOperationException(
+        "RunElevatedOnWindows is only supported with admin role."
+      );
+    }
+
+    // If a debugger is attached, the process is elevated as the godotenv command is not elevated globally
+    Process process = new() {
+      StartInfo = new() {
+        FileName = exe,
+        Arguments = args,
+        UseShellExecute = Debugger.IsAttached,
+        Verb = Debugger.IsAttached ? "runas" : string.Empty,
+        CreateNoWindow = !Debugger.IsAttached,
+      }
+    };
 
     process.Start();
 

--- a/GodotEnv/src/features/addons/commands/install/AddonsInstallCommand.cs
+++ b/GodotEnv/src/features/addons/commands/install/AddonsInstallCommand.cs
@@ -1,6 +1,7 @@
 namespace Chickensoft.GodotEnv.Features.Addons.Commands;
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Chickensoft.GodotEnv.Common.Models;
 using CliFx;
@@ -26,7 +27,16 @@ public class AddonsInstallCommand : ICommand, ICliCommand {
   public async ValueTask ExecuteAsync(IConsole console) {
     var log = ExecutionContext.CreateLog(console);
     var addonsFileRepo = ExecutionContext.Addons.AddonsFileRepo;
+    var addonsRepo = ExecutionContext.Addons.AddonsRepo;
     var logic = ExecutionContext.Addons.AddonsLogic;
+
+    // The install command should be run with admin role on Windows if the addons file contains addons with a symlink source
+    // To be able to debug, godotenv is not elevated globally if a debugger is attached
+    if (addonsFileRepo.AddonsFileContainsSymlinkAddons(ExecutionContext.WorkingDir) && addonsFileRepo.FileClient.OS == OSType.Windows && 
+        !addonsRepo.ProcessRunner.IsElevatedOnWindows() && !Debugger.IsAttached) {
+      await addonsRepo.ProcessRunner.ElevateOnWindows();
+      return;
+    }
 
     var binding = logic.Bind();
 

--- a/GodotEnv/src/features/addons/domain/AddonsFileRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsFileRepository.cs
@@ -18,6 +18,13 @@ public interface IAddonsFileRepository {
   AddonsFile LoadAddonsFile(string projectPath, out string filename);
 
   /// <summary>
+  /// Check the addons file and return true if an addon have a symlink source.
+  /// </summary>
+  /// <param name="projectPath">Where to search for an addons file.</param>
+  /// <returns>A boolean indicating if an addon have a symlink source in the addons file.</returns>
+  bool AddonsFileContainsSymlinkAddons(string projectPath);
+
+  /// <summary>
   /// Creates an addons configuration object that represents the configuration
   /// for how addons should be managed.
   /// </summary>
@@ -49,6 +56,15 @@ public class AddonsFileRepository : IAddonsFileRepository {
       filename: out filename,
       defaultValue: new AddonsFile()
     );
+
+  public bool AddonsFileContainsSymlinkAddons(string projectPath) {
+    string? file = FileClient.FileThatExists(new string[] { "addons.json", "addons.jsonc" }, projectPath);
+    if(string.IsNullOrEmpty(file)) return false;
+    return FileClient.FileContains(
+      path: file,
+      str: "\"symlink\""
+    );
+  }
 
   public AddonsConfiguration CreateAddonsConfiguration(
     string projectPath, AddonsFile addonsFile

--- a/GodotEnv/src/features/addons/domain/AddonsRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsRepository.cs
@@ -11,6 +11,7 @@ public interface IAddonsRepository {
   IFileClient FileClient { get; }
   AddonsConfiguration Config { get; }
   IComputer Computer { get; }
+  IProcessRunner ProcessRunner { get; }
 
   /// <summary>
   /// <para>
@@ -82,11 +83,13 @@ public interface IAddonsRepository {
 public class AddonsRepository(
   IFileClient fileClient,
   IComputer computer,
-  AddonsConfiguration config
+  AddonsConfiguration config,
+  IProcessRunner processRunner
 ) : IAddonsRepository {
   public IFileClient FileClient { get; } = fileClient;
   public IComputer Computer { get; } = computer;
   public AddonsConfiguration Config { get; } = config;
+  public IProcessRunner ProcessRunner { get; } = processRunner;
 
   public string ResolveUrl(IAsset asset, string path) {
     var url = asset.Url;

--- a/GodotEnv/src/features/godot/commands/cache/GodotCacheClearCommand.cs
+++ b/GodotEnv/src/features/godot/commands/cache/GodotCacheClearCommand.cs
@@ -1,5 +1,6 @@
 namespace Chickensoft.GodotEnv.Features.Godot.Commands;
 
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Chickensoft.GodotEnv.Common.Models;
 using CliFx;
@@ -19,6 +20,18 @@ public class GodotCacheClearCommand : ICommand, ICliCommand {
   }
 
   public async ValueTask ExecuteAsync(IConsole console) {
+    var godotRepo = ExecutionContext.Godot.GodotRepo;
+    var platform = ExecutionContext.Godot.Platform;
+
+    // The clear command must be run with the admin role on Windows
+    // To be able to debug, godotenv is not elevated globally if a debugger is attached
+    if (platform.FileClient.OS == OSType.Windows && !godotRepo.ProcessRunner.IsElevatedOnWindows() &&
+        !Debugger.IsAttached)
+    {
+      await godotRepo.ProcessRunner.ElevateOnWindows();
+      return;
+    }
+
     var log = ExecutionContext.CreateLog(console);
 
     log.Print("");

--- a/GodotEnv/src/features/godot/commands/env/GodotEnvSetupCommand.cs
+++ b/GodotEnv/src/features/godot/commands/env/GodotEnvSetupCommand.cs
@@ -1,5 +1,6 @@
 namespace Chickensoft.GodotEnv.Features.Godot.Commands;
 
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Chickensoft.GodotEnv.Common.Models;
 using CliFx;
@@ -19,9 +20,19 @@ public class GodotEnvSetupCommand : ICommand, ICliCommand {
   }
 
   public async ValueTask ExecuteAsync(IConsole console) {
-    var log = ExecutionContext.CreateLog(console);
     var godotRepo = ExecutionContext.Godot.GodotRepo;
+    var platform = ExecutionContext.Godot.Platform;
 
+    // The setup command must be run with the admin role on Windows
+    // To be able to debug, godotenv is not elevated globally if a debugger is attached
+    if (platform.FileClient.OS == OSType.Windows && !godotRepo.ProcessRunner.IsElevatedOnWindows() &&
+        !Debugger.IsAttached)
+    {
+      await godotRepo.ProcessRunner.ElevateOnWindows();
+      return;
+    }
+
+    var log = ExecutionContext.CreateLog(console);
     await godotRepo.AddOrUpdateGodotEnvVariable(log);
   }
 }

--- a/GodotEnv/src/features/godot/domain/GodotRepository.cs
+++ b/GodotEnv/src/features/godot/domain/GodotRepository.cs
@@ -26,6 +26,7 @@ public interface IGodotRepository {
   IZipClient ZipClient { get; }
   ISystemEnvironmentVariableClient SystemEnvironmentVariableClient { get; }
   IGodotEnvironment Platform { get; }
+  IProcessRunner ProcessRunner { get; }
   string GodotInstallationsPath { get; }
   string GodotCachePath { get; }
   string GodotSymlinkPath { get; }
@@ -133,6 +134,7 @@ public class GodotRepository : IGodotRepository {
   public ISystemEnvironmentVariableClient SystemEnvironmentVariableClient {
     get;
   }
+  public IProcessRunner ProcessRunner { get; }
 
   private const string GODOT_REMOTE_VERSIONS_URL = "https://api.nuget.org/v3-flatcontainer/godotsharp/index.json";
 
@@ -171,7 +173,8 @@ public class GodotRepository : IGodotRepository {
     INetworkClient networkClient,
     IZipClient zipClient,
     IGodotEnvironment platform,
-    ISystemEnvironmentVariableClient systemEnvironmentVariableClient
+    ISystemEnvironmentVariableClient systemEnvironmentVariableClient,
+    IProcessRunner processRunner
   ) {
     Config = config;
     FileClient = fileClient;
@@ -179,6 +182,7 @@ public class GodotRepository : IGodotRepository {
     ZipClient = zipClient;
     Platform = platform;
     SystemEnvironmentVariableClient = systemEnvironmentVariableClient;
+    ProcessRunner = processRunner;
   }
 
   public GodotInstallation? GetInstallation(


### PR DESCRIPTION
This pull request is related to #42.

I've added elevation at the start of a command execution (when elevation is required), to rerun the command with administrator rights on Windows (except in debugging, to allow the use of breakpoints).

As AddonsInstallCommand only needs to be elevated if an addon has a "symlink" source in the addons file, I've added elevation only if at least one addon has a "symlink" source.

For information, I've added two methods (FileContains in FileClient and AddonsFileContainsSymlinkAddons in AddonsFileRepo) without adding tests for them for the moment. I'll try to add them this week-end.

Let me know if you have any questions/remarks. I've checked the option to allow edits, so feel free to add commits directly to the forked repo if needed.