### PR TITLE
Fix: Support labels with dots in the ChecksumClient

### DIFF
--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -102,6 +102,7 @@ jobs:
       matrix:
         # Also try windows-2019?
         os: [macos-latest, ubuntu-latest, windows-2019]
+        version: ["4.1.1", "4.3.0-dev.6"]
     defaults:
       run:
         # Use bash shells on all platforms.
@@ -128,7 +129,7 @@ jobs:
         run: |
           # Use tool to install Godot. Last line of output is the path to the
           # symlink that always points to the active version of Godot.
-          dotnet run -- godot install 4.1.1
+          dotnet run -- godot install ${{ matrix.version }}
 
       - name: 🤖 Check Godot Location
         working-directory: GodotEnv
@@ -174,6 +175,6 @@ jobs:
           echo "Before uninstall:"
           dotnet run -- godot list
           echo "Uninstalling..."
-          dotnet run -- godot uninstall 4.1.1
+          dotnet run -- godot uninstall ${{ matrix.version }}
           echo "After uninstall:"
           dotnet run -- godot list

--- a/GodotEnv.Tests/src/features/godot/domain/GodotChecksumClientTest.cs
+++ b/GodotEnv.Tests/src/features/godot/domain/GodotChecksumClientTest.cs
@@ -27,6 +27,8 @@ public class GodotChecksumClientTest {
     yield return [new SemanticVersion("1", "0", "0"), false, GetChecksumFileUrl("1.0-stable")];
     yield return [new SemanticVersion("4", "0", "0", "alpha14"), false, GetChecksumFileUrl("4.0-alpha14")];
     yield return [new SemanticVersion("4", "2", "2", "rc1"), false, GetChecksumFileUrl("4.2.2-rc1")];
+    // GodotSharp nuget packages use a dot in the label, and this has to be supported as well.
+    yield return [new SemanticVersion("4", "3", "0", "dev.6"), false, GetChecksumFileUrl("4.3-dev6")];
   }
 
   [Theory]

--- a/GodotEnv/src/features/godot/domain/GodotChecksumClient.cs
+++ b/GodotEnv/src/features/godot/domain/GodotChecksumClient.cs
@@ -48,8 +48,8 @@ public class GodotChecksumClient(
   private IGodotEnvironment Platform { get; } = platform;
 
   private static string GetChecksumFileUrl(GodotCompressedArchive archive) {
-    var suffix = archive.Version.Label == string.Empty ? "-stable" : string.Empty;
-    var releaseFilename = $"godot-{archive.Version.AsGodotVersionString}{suffix}.json";
+    var suffix = archive.Version.LabelNoDots == string.Empty ? "-stable" : string.Empty;
+    var releaseFilename = $"godot-{archive.Version.Format(true, true)}{suffix}.json";
     return $"https://raw.githubusercontent.com/godotengine/godot-builds/main/releases/{releaseFilename}";
   }
 

--- a/GodotEnv/src/features/godot/models/SemanticVersion.cs
+++ b/GodotEnv/src/features/godot/models/SemanticVersion.cs
@@ -57,15 +57,21 @@ public record SemanticVersion(
   public string LabelNoDots => Label.Replace(".", "");
 
   /// <summary>Reconstructed version string.</summary>
-  public string VersionString => $"{Major}.{Minor}.{Patch}" +
-    (Label != "" ? $"-{Label}" : "");
+  public string VersionString => Format(false, false);
 
   /// <summary>
-  /// Version string as Godot uses them (if Patch is zero, it isn't included).
+  /// Formats a Semantic version in different forms as various Godot locations
+  /// use them.
   /// </summary>
-  public string AsGodotVersionString => $"{Major}.{Minor}" +
-    (Patch != "0" ? $".{Patch}" : "") +
-    (Label != "" ? $"-{Label}" : "");
+  /// <param name="omitPatchIfZero">If true, a patch of 0 will be omitted.</param>
+  /// <param name="noDotsInLabel">If true, all dots will be removed from the label.</param>
+  /// <returns></returns>
+  public string Format(bool omitPatchIfZero, bool noDotsInLabel) {
+    var label = noDotsInLabel ? LabelNoDots : Label;
+    var patch = (omitPatchIfZero && Patch == "0") ? "" : $".{Patch}";
+
+    return $"{Major}.{Minor}{patch}" + (label != "" ? $"-{label}" : "");
+  }
 
   public override string ToString() =>
     $"Major({Major}).Minor({Minor}).Patch({Patch})-Label({Label})";


### PR DESCRIPTION
This PR adapts the `GodotChecksumClient` to remove dots from labels when fetching a checksum file, to fix the bug I introduced accidentally in the previous PR.

Additionally, I'm attempting to add a nuget formatted pre-release version to the tests, to catch such a bug in the future. I'm not too familiar with GitHub actions, so this might need to be reviewed carefully.