### PR TITLE
issue#68

### DIFF
--- a/GodotEnv/src/features/godot/domain/GodotRepository.cs
+++ b/GodotEnv/src/features/godot/domain/GodotRepository.cs
@@ -172,7 +172,7 @@ public class GodotRepository : IGodotRepository {
   // Regex for converting directory names back into version strings to see
   // what versions we have installed.
   public static readonly Regex DirectoryToVersionStringRegex = new(
-    @"godot_(dotnet_)?(?<major>\d+)_(?<minor>\d+)_(?<patch>\d+)_?(?<label>[a-zA-Z]+_[\d]+)?",
+    @"godot_(dotnet_)?(?<major>\d+)_(?<minor>\d+)_(?<patch>\d+)_?(?<label>[a-zA-Z]+_?[\d]+)?",
     RegexOptions.Compiled | RegexOptions.IgnoreCase
   );
 


### PR DESCRIPTION
[issue#68](https://github.com/chickensoft-games/GodotEnv/issues/68)
adjusted regex to include labels like "rc2" or "beta1" instead of only "rc_1"