### PR TITLE
feat: Add Windows on ARM support (#73)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ GodotEnv.sln.DotSettings.user
 
 # File-based project format
 *.iws
+
+### Visual Studio ###
+.vs/

--- a/GodotEnv.Tests/src/common/clients/FileClientTest.cs
+++ b/GodotEnv.Tests/src/common/clients/FileClientTest.cs
@@ -42,6 +42,7 @@ public class FileClientTest {
   [Fact]
   public void InitializesLinux() {
     FileClient.IsOSPlatform = (platform) => platform == OSPlatform.Linux;
+    FileClient.ProcessorArchitecture = Architecture.X64;
     var fs = GetFs('/');
     var computer = new Mock<IComputer>();
     var client = new FileClient(fs.Object, computer.Object, new Mock<IProcessRunner>().Object);
@@ -50,12 +51,15 @@ public class FileClientTest {
     client.OSFamily.ShouldBe(OSFamily.Unix);
     client.Separator.ShouldBe('/');
     client.OS.ShouldBe(OSType.Linux);
+    client.Processor.ShouldBe(ProcessorType.other);
     FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
+    FileClient.ProcessorArchitecture = FileClient.ProcessorArchitectureDefault;
   }
 
   [Fact]
   public void InitializesMacOS() {
     FileClient.IsOSPlatform = (platform) => platform == OSPlatform.OSX;
+    FileClient.ProcessorArchitecture = Architecture.X64;
     var fs = GetFs('/');
     var computer = new Mock<IComputer>();
     var client = new FileClient(
@@ -66,7 +70,9 @@ public class FileClientTest {
     client.OSFamily.ShouldBe(OSFamily.Unix);
     client.Separator.ShouldBe('/');
     client.OS.ShouldBe(OSType.MacOS);
+    client.Processor.ShouldBe(ProcessorType.other);
     FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
+    FileClient.ProcessorArchitecture = FileClient.ProcessorArchitectureDefault;
   }
 
   [Fact]
@@ -82,19 +88,42 @@ public class FileClientTest {
     client.OSFamily.ShouldBe(OSFamily.Windows);
     client.Separator.ShouldBe('\\');
     client.OS.ShouldBe(OSType.Windows);
+    client.Processor.ShouldBe(ProcessorType.arm64);
     FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
+  }
+
+  [Fact]
+  public void InitializesWindowsArm() {
+    FileClient.IsOSPlatform = (platform) => platform == OSPlatform.Windows;
+    FileClient.ProcessorArchitecture = Architecture.Arm64;
+    var fs = GetFs('\\');
+    var computer = new Mock<IComputer>();
+    var client = new FileClient(
+      fs.Object, computer.Object, new Mock<IProcessRunner>().Object
+    );
+    client.ShouldBeAssignableTo<IFileClient>();
+    client.Files.ShouldBe(fs.Object);
+    client.OSFamily.ShouldBe(OSFamily.Windows);
+    client.Separator.ShouldBe('\\');
+    client.OS.ShouldBe(OSType.Windows);
+    client.Processor.ShouldBe(ProcessorType.arm64);
+    FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
+    FileClient.ProcessorArchitecture = FileClient.ProcessorArchitectureDefault;
   }
 
   [Fact]
   public void InitializesUnknownOS() {
     FileClient.IsOSPlatform = (platform) => false;
+    FileClient.ProcessorArchitecture = Architecture.X64;
     var fs = GetFs('\\');
     var computer = new Mock<IComputer>();
     var client = new FileClient(
       fs.Object, computer.Object, new Mock<IProcessRunner>().Object
     );
     client.OS.ShouldBe(OSType.Unknown);
+    client.Processor.ShouldBe(ProcessorType.other);
     FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
+    FileClient.ProcessorArchitecture = FileClient.ProcessorArchitectureDefault;
   }
 
   [Fact]

--- a/GodotEnv.Tests/src/features/godot/models/GodotEnvironmentTest.cs
+++ b/GodotEnv.Tests/src/features/godot/models/GodotEnvironmentTest.cs
@@ -1,5 +1,6 @@
 namespace Chickensoft.GodotEnv.Tests.features.godot.models;
 
+using Chickensoft.GodotEnv.Common.Models;
 using Chickensoft.GodotEnv.Features.Godot.Models;
 using Common.Clients;
 using Common.Utilities;
@@ -37,6 +38,8 @@ public class GodotEnvironmentTest {
 
   [Fact]
   public void GetsExpectedWindowsDownloadUrl() {
+    fileClient.Setup(f => f.Processor).Returns(ProcessorType.other);
+
     var platform = new Windows(fileClient.Object, computer.Object);
 
     var downloadUrl = platform.GetDownloadUrl(version4, false, false);
@@ -48,6 +51,8 @@ public class GodotEnvironmentTest {
 
   [Fact]
   public void GetsExpectedWindowsMonoDownloadUrl() {
+    fileClient.Setup(f => f.Processor).Returns(ProcessorType.other);
+
     var platform = new Windows(fileClient.Object, computer.Object);
 
     var downloadUrl = platform.GetDownloadUrl(version4, true, false);
@@ -55,6 +60,32 @@ public class GodotEnvironmentTest {
 
     downloadUrl = platform.GetDownloadUrl(version3, true, false);
     downloadUrl.ShouldBe(GetExpectedDownloadUrl(version3, "stable_mono_win64"));
+  }
+
+  [Fact]
+  public void GetsExpectedWindowsArmDownloadUrl() {
+    fileClient.Setup(f => f.Processor).Returns(ProcessorType.arm64);
+
+    var platform = new Windows(fileClient.Object, computer.Object);
+
+    var downloadUrl = platform.GetDownloadUrl(version4, false, false);
+    downloadUrl.ShouldBe($"{GodotEnvironment.GODOT_URL_PREFIX}4.1.2-stable/Godot_v4.1.2-stable_windows_arm64.exe.zip");
+
+    downloadUrl = platform.GetDownloadUrl(version3, false, false);
+    downloadUrl.ShouldBe($"{GodotEnvironment.GODOT_URL_PREFIX}{version3.VersionString}-stable/Godot_v{version3.VersionString}-stable_windows_arm64.exe.zip");
+  }
+
+  [Fact]
+  public void GetsExpectedWindowsArmMonoDownloadUrl() {
+    fileClient.Setup(f => f.Processor).Returns(ProcessorType.arm64);
+
+    var platform = new Windows(fileClient.Object, computer.Object);
+
+    var downloadUrl = platform.GetDownloadUrl(version4, true, false);
+    downloadUrl.ShouldBe(GetExpectedDownloadUrl(version4, "stable_mono_windows_arm64"));
+
+    downloadUrl = platform.GetDownloadUrl(version3, true, false);
+    downloadUrl.ShouldBe(GetExpectedDownloadUrl(version3, "stable_mono_windows_arm64"));
   }
 
   [Fact]

--- a/GodotEnv/src/common/clients/FileClient.cs
+++ b/GodotEnv/src/common/clients/FileClient.cs
@@ -31,6 +31,9 @@ public interface IFileClient {
   /// <summary>The operating system type.</summary>
   OSType OS { get; }
 
+  /// <summary>The process architecture type.</summary>
+  ProcessorType Processor { get; }
+
   /// <summary>Path directory separator.</summary>
   char Separator { get; }
 
@@ -309,6 +312,7 @@ public class FileClient : IFileClient {
   public IProcessRunner ProcessRunner { get; }
   public OSFamily OSFamily { get; }
   public OSType OS { get; }
+  public ProcessorType Processor { get; }
   public char Separator { get; }
 
   // Shims for testing.
@@ -318,6 +322,12 @@ public class FileClient : IFileClient {
 
   public static Func<OSPlatform, bool> IsOSPlatform { get; set; } =
     IsOSPlatformDefault;
+
+  public static Architecture ProcessorArchitectureDefault { get; } =
+    RuntimeInformation.ProcessArchitecture;
+
+  public static Architecture ProcessorArchitecture { get; set; } =
+    ProcessorArchitectureDefault;
 
   public string UserDirectory => Path.TrimEndingDirectorySeparator(
     Environment.GetFolderPath(
@@ -353,6 +363,9 @@ public class FileClient : IFileClient {
         : IsOSPlatform(OSPlatform.Windows)
           ? OSType.Windows
           : OSType.Unknown;
+    Processor = ProcessorArchitecture == Architecture.Arm64
+      ? ProcessorType.arm64
+      : ProcessorType.other;
   }
 
   public string Sanitize(string path) =>

--- a/GodotEnv/src/common/models/ProcessorType.cs
+++ b/GodotEnv/src/common/models/ProcessorType.cs
@@ -1,0 +1,11 @@
+namespace Chickensoft.GodotEnv.Common.Models;
+
+/// <summary>
+/// Processor architecture type.
+/// </summary>
+public enum ProcessorType {
+  /// <summary>arm64.</summary>
+  arm64,
+  /// <summary>Other.</summary>
+  other,
+}

--- a/GodotEnv/src/features/godot/models/Windows.cs
+++ b/GodotEnv/src/features/godot/models/Windows.cs
@@ -3,11 +3,17 @@ namespace Chickensoft.GodotEnv.Features.Godot.Models;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Chickensoft.GodotEnv.Common.Clients;
+using Chickensoft.GodotEnv.Common.Models;
 using Chickensoft.GodotEnv.Common.Utilities;
 
 public class Windows : GodotEnvironment {
   public Windows(IFileClient fileClient, IComputer computer)
     : base(fileClient, computer) { }
+
+  private string ProcessorArchitecture =>
+    FileClient.Processor == ProcessorType.arm64
+      ? "windows_arm64"
+      : "win64";
 
   public override string ExportTemplatesBasePath =>
     FileClient.GetFullPath(
@@ -15,7 +21,7 @@ public class Windows : GodotEnvironment {
     );
 
   public override string GetInstallerNameSuffix(bool isDotnetVersion, SemanticVersion version) =>
-    isDotnetVersion ? "_mono_win64" : "_win64.exe";
+    isDotnetVersion ? $"_mono_{ProcessorArchitecture}" : $"_{ProcessorArchitecture}.exe";
 
   public override Task<bool> IsExecutable(IShell shell, IFileInfo file) =>
     Task.FromResult(file.Name.ToLower().EndsWith(".exe"));
@@ -27,13 +33,13 @@ public class Windows : GodotEnvironment {
   ) {
     var fsVersionString = GetFilenameVersionString(version);
     var name = fsVersionString +
-      $"{(isDotnetVersion ? "_mono" : "")}_win64.exe";
+      $"{(isDotnetVersion ? "_mono" : "")}_{ProcessorArchitecture}.exe";
 
     // Both versions extract to a folder. The dotnet folder name is different
     // from the non-dotnet folder name :P
 
     if (isDotnetVersion) {
-      return FileClient.Combine(fsVersionString + "_mono_win64", name);
+      return FileClient.Combine(fsVersionString + $"_mono_{ProcessorArchitecture}", name);
     }
 
     // There is no subfolder for non-dotnet versions.
@@ -44,6 +50,6 @@ public class Windows : GodotEnvironment {
     SemanticVersion version,
     bool isDotnetVersion
   ) => FileClient.Combine(
-    GetFilenameVersionString(version) + "_mono_win64", "GodotSharp"
+    GetFilenameVersionString(version) + $"_mono_{ProcessorArchitecture}", "GodotSharp"
   );
 }


### PR DESCRIPTION
This update introduces support for Windows on ARM by using the ARM64 URL during installation.

**Verification**:
- Verified on both Windows ARM64 and Windows x64 systems.
- Added unit tests.

**Note**:
1. **No x64 Option for ARM64 Systems**: The current version does not provide an option to install the x64 version on ARM64 systems.
2. **File Caching Issue**: The file caching mechanism results in the same filename being used regardless of the processor architecture. This means that if a version has previously been downloaded, the same x64 download will be installed after this update on ARM64 systems, leading to an error during post-installation path validation.
3. **Compatibility with Pre-4.3 Versions**: Attempting to install a version earlier than 4.3 will fail with the error: "*Download failed. The remote server returned an error: (404) Not Found.*"
4. **List Command Limitation**: The `godot list` command does not currently display which processor architecture a version refers to. This could obscure the fact that different versions were installed previously using x64 architecture. This limitation affects older installations only unless future changes allow for x64 versions to be installed on ARM64 systems as well.
5. **Uninstalling x64 versions**: The current version does not account for scenarios where an installed version is x64 on ARM64 systems, which will likely require users to have to manually uninstall these versions if desired.

**Feedback Request**:
- Should I address any of the issues listed above before this pull request is merged?
- Are there any coding guidelines that I have missed?

I'm open to feedback.

Resolves #73