### PR TITLE
chore: Update Project to .NET 8.0 and Resolve Associated Warnings

### DIFF
--- a/GodotEnv.Tests/Chickensoft.GodotEnv.Tests.csproj
+++ b/GodotEnv.Tests/Chickensoft.GodotEnv.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>

--- a/GodotEnv.Tests/src/MainTest.cs
+++ b/GodotEnv.Tests/src/MainTest.cs
@@ -10,7 +10,7 @@ public class MainTest {
   [Fact]
   public async Task CallsCliFx()
     => await Should.NotThrowAsync(
-      async () => await GodotEnv.Main(new string[] { "not-a-command" })
+      async () => await GodotEnv.Main(["not-a-command"])
     );
 
   [Fact]
@@ -24,8 +24,8 @@ public class MainTest {
       args, config, workingDir, addonsContext.Object,
       godotContext.Object
     );
-    context.CliArgs.ShouldBe(new string[] { "a" });
-    context.CommandArgs.ShouldBe(new string[] { "b" });
+    context.CliArgs.ShouldBe(["a"]);
+    context.CommandArgs.ShouldBe(["b"]);
     context.Config.ShouldBe(config);
     context.WorkingDir.ShouldBe(workingDir);
     context.Addons.ShouldBe(addonsContext.Object);
@@ -34,7 +34,7 @@ public class MainTest {
 }
 
 public class GodotEnvActivatorTest {
-  private class ITestCommand(IExecutionContext executionContext) :
+  private sealed class ITestCommand(IExecutionContext executionContext) :
     ICliCommand {
     public IExecutionContext ExecutionContext { get; } = executionContext;
   }

--- a/GodotEnv.Tests/src/common/clients/FileClientTest.cs
+++ b/GodotEnv.Tests/src/common/clients/FileClientTest.cs
@@ -159,8 +159,9 @@ public class FileClientTest {
     fs.Setup(fs => fs.Path).Returns(path.Object);
     path.Setup(path => path.DirectorySeparatorChar)
       .Returns('/');
+    var expectedArgs = new[] { "a", "b" };
     path.Setup(path => path.Combine(
-      It.Is<string[]>(args => args.SequenceEqual(new[] { "a", "b" })))
+      It.Is<string[]>(args => args.SequenceEqual(expectedArgs)))
     ).Returns("a/b");
 
     var computer = new Mock<IComputer>();
@@ -366,11 +367,11 @@ public class FileClientTest {
       fs, computer.Object, new Mock<IProcessRunner>().Object
     );
 
-    client.FileThatExists(new string[] { "0.txt", "b.txt", "a.txt" }, "/")
+    client.FileThatExists(["0.txt", "b.txt", "a.txt"], "/")
       .ShouldBe("/b.txt");
-    client.FileThatExists(new string[] { "0.txt", "a.txt", "b.txt" }, "/")
+    client.FileThatExists(["0.txt", "a.txt", "b.txt"], "/")
       .ShouldBe("/a.txt");
-    client.FileThatExists(new string[] { "0.txt", "1.txt" }, "/")
+    client.FileThatExists(["0.txt", "1.txt"], "/")
       .ShouldBeNull();
   }
 
@@ -462,7 +463,7 @@ public class FileClientTest {
 
     client.ReadJsonFile(
       "",
-      new string[] { "model_a.json", "model_b.json" },
+      ["model_a.json", "model_b.json"],
       out var filename,
       new TestJsonModel(name: "default")
     ).ShouldBe(new TestJsonModel(name: "test"));
@@ -484,7 +485,7 @@ public class FileClientTest {
     var e = Should.Throw<IOException>(
       () => client.ReadJsonFile(
         "",
-        new string[] { "model.json" },
+        ["model.json"],
         out var filename,
         new TestJsonModel(name: "default")
       )
@@ -507,7 +508,7 @@ public class FileClientTest {
     Should.Throw<IOException>(
       () => client.ReadJsonFile(
         "",
-        new string[] { "model.json", "model_a.json", "model_b.json" },
+        ["model.json", "model_a.json", "model_b.json"],
         out var filename,
         new TestJsonModel(name: "default")
       )
@@ -527,7 +528,7 @@ public class FileClientTest {
 
     client.ReadJsonFile(
       "",
-      new string[] { "model.json", "model_a.json", "model_b.json" },
+      ["model.json", "model_a.json", "model_b.json"],
       out var filename,
       new TestJsonModel(name: "default")
     ).ShouldBe(new TestJsonModel(name: "alternative"));
@@ -546,7 +547,7 @@ public class FileClientTest {
 
     client.ReadJsonFile(
       "",
-      new string[] { "model.json", "model_a.json", "model_b.json" },
+      ["model.json", "model_a.json", "model_b.json"],
       out var filename,
       new TestJsonModel(name: "default")
     ).ShouldBe(new TestJsonModel(name: "default"));

--- a/GodotEnv.Tests/src/common/models/ExecutionContextTest.cs
+++ b/GodotEnv.Tests/src/common/models/ExecutionContextTest.cs
@@ -10,8 +10,8 @@ using Xunit;
 public class ExecutionContextTest {
   private const string VERSION = "1.2.3";
   private const string WORKING_DIR = "/";
-  private readonly string[] _cliArgs = new string[] { "a", "b" };
-  private readonly string[] _commandArgs = new string[] { "c", "d" };
+  private readonly string[] _cliArgs = ["a", "b"];
+  private readonly string[] _commandArgs = ["c", "d"];
 
   [Fact]
   public void Initializes() {

--- a/GodotEnv.Tests/src/common/utilities/ProcessRunnerTest.cs
+++ b/GodotEnv.Tests/src/common/utilities/ProcessRunnerTest.cs
@@ -9,7 +9,7 @@ public class ProcessRunnerTest {
   public async Task RunsProcessOnWindows() {
     var runner = new ProcessRunner();
     var result = await runner.Run(
-      Environment.CurrentDirectory, "cmd", new[] { "/c echo \"hello\"" }
+      Environment.CurrentDirectory, "cmd", ["/c echo \"hello\""]
     );
     result.ExitCode.ShouldBe(0);
     result.Succeeded.ShouldBe(true);
@@ -21,7 +21,7 @@ public class ProcessRunnerTest {
   public async Task RunsProcessOnMacLinux() {
     var runner = new ProcessRunner();
     var result = await runner.Run(
-      Environment.CurrentDirectory, "echo", new[] { "hello" }
+      Environment.CurrentDirectory, "echo", ["hello"]
     );
     result.ExitCode.ShouldBe(0);
     result.Succeeded.ShouldBe(true);

--- a/GodotEnv.Tests/src/features/addons/domain/AddonsFileRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/addons/domain/AddonsFileRepositoryTest.cs
@@ -20,12 +20,11 @@ public partial class AddonsFileRepositoryTest {
 
     var value = new AddonsFile();
 
+    var expectedArgs = new[] { "addons.json", "addons.jsonc" };
     fileClient.Setup(client => client.ReadJsonFile(
       projectPath,
       It.Is<string[]>(
-        value => value.SequenceEqual(
-          new string[] { "addons.json", "addons.jsonc" }
-        )
+        value => value.SequenceEqual(expectedArgs)
       ),
       out filename,
       It.IsAny<AddonsFile>()

--- a/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
@@ -361,7 +361,7 @@ public class AddonsRepositoryTest {
     );
 
     cli.Runs(addonInstallPath, new ProcessResult(0), "git", "init");
-    cli.Runs(addonInstallPath, new ProcessResult(0), 
+    cli.Runs(addonInstallPath, new ProcessResult(0),
       "git", "config", "--local", "user.email", "godotenv@godotenv.com"
     );
     cli.Runs(addonInstallPath, new ProcessResult(0),

--- a/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
@@ -13,7 +13,7 @@ using Shouldly;
 using Xunit;
 
 public class AddonsRepositoryTest {
-  private class Subject(
+  private sealed class Subject(
     IConsole console,
     Mock<IFileClient> client,
     Mock<ILog> log,

--- a/GodotEnv.Tests/src/features/godot/domain/GodotChecksumClientTest.cs
+++ b/GodotEnv.Tests/src/features/godot/domain/GodotChecksumClientTest.cs
@@ -1,4 +1,4 @@
-namespace Chickensoft.GodotEnv.Tests.features.godot.domain;
+namespace Chickensoft.GodotEnv.Tests.Features.Godot.Domain;
 
 using System;
 using System.Collections.Generic;
@@ -14,9 +14,9 @@ using Moq;
 using Xunit;
 
 public class GodotChecksumClientTest {
-  private static readonly string GODOT_4_3_DEV_5_MACOS_CHECKSUM = "0fdd44c725980c463d86b14aeb47fc41a35ff9005e9df9a9c821168b21d60f845d80313e93c892565daadef04d02c6f6fbb6a9d9a26374db9caa8cd4d9354d7c";
+  private const string GODOT_4_3_DEV_5_MACOS_CHECKSUM = "0fdd44c725980c463d86b14aeb47fc41a35ff9005e9df9a9c821168b21d60f845d80313e93c892565daadef04d02c6f6fbb6a9d9a26374db9caa8cd4d9354d7c";
 
-  private static readonly string GODOT_ENV_STRING_CHECKSUM =
+  private const string GODOT_ENV_STRING_CHECKSUM =
     "3a2e1fa23f9e99ff976803d6fb1283707e015b7904040f604a6a10240c1eba138c6feed88e9ec5db72aee81c6f9b1eba99292e346eab054004e2427a4d4b39b8";
 
   private static string GetChecksumFileUrl(string version) =>
@@ -179,8 +179,7 @@ public class GodotChecksumClientTest {
     string godotReleaseJson;
     await using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName)
                               ?? throw new FileNotFoundException("Failed to get test release JSON file.")) {
-      using (var reader = new StreamReader(stream))
-      {
+      using (var reader = new StreamReader(stream)) {
         godotReleaseJson = await reader.ReadToEndAsync();
       }
     }
@@ -191,8 +190,9 @@ public class GodotChecksumClientTest {
           It.IsAny<string>()
         ))
       .ReturnsAsync(() => {
-        var response = new HttpResponseMessage(HttpStatusCode.OK);
-        response.Content = new StringContent(godotReleaseJson);
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+          Content = new StringContent(godotReleaseJson)
+        };
         return response;
       });
     return networkClient;

--- a/GodotEnv.Tests/src/features/godot/models/GodotEnvironmentTest.cs
+++ b/GodotEnv.Tests/src/features/godot/models/GodotEnvironmentTest.cs
@@ -1,4 +1,4 @@
-namespace Chickensoft.GodotEnv.Tests.features.godot.models;
+namespace Chickensoft.GodotEnv.Tests.Features.Godot.Models;
 
 using Chickensoft.GodotEnv.Features.Godot.Models;
 using Common.Clients;
@@ -8,89 +8,89 @@ using Shouldly;
 using Xunit;
 
 public class GodotEnvironmentTest {
-  private readonly Mock<IComputer> computer = new();
-  private readonly Mock<IFileClient> fileClient = new();
-  private readonly SemanticVersion version4 = new("4", "1", "2");
-  private readonly SemanticVersion version3 = new("3", "5", "3");
+  private readonly Mock<IComputer> _computer = new();
+  private readonly Mock<IFileClient> _fileClient = new();
+  private readonly SemanticVersion _version4 = new("4", "1", "2");
+  private readonly SemanticVersion _version3 = new("3", "5", "3");
 
   [Fact]
   public void GetsExpectedMacDownloadUrl() {
-    var platform = new MacOS(fileClient.Object, computer.Object);
+    var platform = new MacOS(_fileClient.Object, _computer.Object);
 
-    var downloadUrl = platform.GetDownloadUrl(version4, false, false);
-    downloadUrl.ShouldBe(GetExpectedDownloadUrl(version4, "stable_macos.universal"));
+    var downloadUrl = platform.GetDownloadUrl(_version4, false, false);
+    downloadUrl.ShouldBe(GetExpectedDownloadUrl(_version4, "stable_macos.universal"));
 
-    downloadUrl = platform.GetDownloadUrl(version3, false, false);
-    downloadUrl.ShouldBe(GetExpectedDownloadUrl(version3, "stable_osx.universal"));
+    downloadUrl = platform.GetDownloadUrl(_version3, false, false);
+    downloadUrl.ShouldBe(GetExpectedDownloadUrl(_version3, "stable_osx.universal"));
   }
 
   [Fact]
   public void GetsExpectedMacMonoDownloadUrl() {
-    var platform = new MacOS(fileClient.Object, computer.Object);
+    var platform = new MacOS(_fileClient.Object, _computer.Object);
 
-    var downloadUrl = platform.GetDownloadUrl(version4, true, false);
-    downloadUrl.ShouldBe(GetExpectedDownloadUrl(version4, "stable_mono_macos.universal"));
+    var downloadUrl = platform.GetDownloadUrl(_version4, true, false);
+    downloadUrl.ShouldBe(GetExpectedDownloadUrl(_version4, "stable_mono_macos.universal"));
 
-    downloadUrl = platform.GetDownloadUrl(version3, true, false);
-    downloadUrl.ShouldBe(GetExpectedDownloadUrl(version3, "stable_mono_osx.universal"));
+    downloadUrl = platform.GetDownloadUrl(_version3, true, false);
+    downloadUrl.ShouldBe(GetExpectedDownloadUrl(_version3, "stable_mono_osx.universal"));
   }
 
   [Fact]
   public void GetsExpectedWindowsDownloadUrl() {
-    var platform = new Windows(fileClient.Object, computer.Object);
+    var platform = new Windows(_fileClient.Object, _computer.Object);
 
-    var downloadUrl = platform.GetDownloadUrl(version4, false, false);
+    var downloadUrl = platform.GetDownloadUrl(_version4, false, false);
     downloadUrl.ShouldBe($"{GodotEnvironment.GODOT_URL_PREFIX}4.1.2-stable/Godot_v4.1.2-stable_win64.exe.zip");
 
-    downloadUrl = platform.GetDownloadUrl(version3, false, false);
-    downloadUrl.ShouldBe($"{GodotEnvironment.GODOT_URL_PREFIX}{version3.VersionString}-stable/Godot_v{version3.VersionString}-stable_win64.exe.zip");
+    downloadUrl = platform.GetDownloadUrl(_version3, false, false);
+    downloadUrl.ShouldBe($"{GodotEnvironment.GODOT_URL_PREFIX}{_version3.VersionString}-stable/Godot_v{_version3.VersionString}-stable_win64.exe.zip");
   }
 
   [Fact]
   public void GetsExpectedWindowsMonoDownloadUrl() {
-    var platform = new Windows(fileClient.Object, computer.Object);
+    var platform = new Windows(_fileClient.Object, _computer.Object);
 
-    var downloadUrl = platform.GetDownloadUrl(version4, true, false);
-    downloadUrl.ShouldBe(GetExpectedDownloadUrl(version4, "stable_mono_win64"));
+    var downloadUrl = platform.GetDownloadUrl(_version4, true, false);
+    downloadUrl.ShouldBe(GetExpectedDownloadUrl(_version4, "stable_mono_win64"));
 
-    downloadUrl = platform.GetDownloadUrl(version3, true, false);
-    downloadUrl.ShouldBe(GetExpectedDownloadUrl(version3, "stable_mono_win64"));
+    downloadUrl = platform.GetDownloadUrl(_version3, true, false);
+    downloadUrl.ShouldBe(GetExpectedDownloadUrl(_version3, "stable_mono_win64"));
   }
 
   [Fact]
   public void GetsExpectedLinuxDownloadUrl() {
-    var platform = new Linux(fileClient.Object, computer.Object);
+    var platform = new Linux(_fileClient.Object, _computer.Object);
 
-    var downloadUrl = platform.GetDownloadUrl(version4, false, false);
-    downloadUrl.ShouldBe(GetExpectedDownloadUrl(version4, "stable_linux.x86_64"));
+    var downloadUrl = platform.GetDownloadUrl(_version4, false, false);
+    downloadUrl.ShouldBe(GetExpectedDownloadUrl(_version4, "stable_linux.x86_64"));
 
-    downloadUrl = platform.GetDownloadUrl(version3, false, false);
-    downloadUrl.ShouldBe(GetExpectedDownloadUrl(version3, "stable_x11.64"));
+    downloadUrl = platform.GetDownloadUrl(_version3, false, false);
+    downloadUrl.ShouldBe(GetExpectedDownloadUrl(_version3, "stable_x11.64"));
   }
 
   [Fact]
   public void GetsExpectedLinuxMonoDownloadUrl() {
-    var platform = new Linux(fileClient.Object, computer.Object);
+    var platform = new Linux(_fileClient.Object, _computer.Object);
 
-    var downloadUrl = platform.GetDownloadUrl(version4, true, false);
-    downloadUrl.ShouldBe(GetExpectedDownloadUrl(version4, "stable_mono_linux_x86_64"));
+    var downloadUrl = platform.GetDownloadUrl(_version4, true, false);
+    downloadUrl.ShouldBe(GetExpectedDownloadUrl(_version4, "stable_mono_linux_x86_64"));
 
-    downloadUrl = platform.GetDownloadUrl(version3, true, false);
-    downloadUrl.ShouldBe(GetExpectedDownloadUrl(version3, "stable_mono_x11_64"));
+    downloadUrl = platform.GetDownloadUrl(_version3, true, false);
+    downloadUrl.ShouldBe(GetExpectedDownloadUrl(_version3, "stable_mono_x11_64"));
   }
 
   [Fact]
   public void GetsExpectedTemplatesDownloadUrl() {
-    var platform = new MacOS(fileClient.Object, computer.Object);
-    var downloadUrl = platform.GetDownloadUrl(version4, false, true);
+    var platform = new MacOS(_fileClient.Object, _computer.Object);
+    var downloadUrl = platform.GetDownloadUrl(_version4, false, true);
 
     downloadUrl.ShouldBe($"{GodotEnvironment.GODOT_URL_PREFIX}4.1.2-stable/Godot_v4.1.2-stable_export_templates.tpz");
   }
 
   [Fact]
   public void GetsExpectedTemplatesMonoDownloadUrl() {
-    var platform = new MacOS(fileClient.Object, computer.Object);
-    var downloadUrl = platform.GetDownloadUrl(version4, true, true);
+    var platform = new MacOS(_fileClient.Object, _computer.Object);
+    var downloadUrl = platform.GetDownloadUrl(_version4, true, true);
 
     downloadUrl.ShouldBe($"{GodotEnvironment.GODOT_URL_PREFIX}4.1.2-stable/Godot_v4.1.2-stable_mono_export_templates.tpz");
   }

--- a/GodotEnv/Chickensoft.GodotEnv.csproj
+++ b/GodotEnv/Chickensoft.GodotEnv.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <LangVersion>preview</LangVersion>
     <PackAsTool>true</PackAsTool>

--- a/GodotEnv/src/Main.cs
+++ b/GodotEnv/src/Main.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 // IMPORTANT: Allow us to test internal methods in our test project.
 [assembly: InternalsVisibleTo("Chickensoft.GodotEnv.Tests")]
@@ -11,7 +11,6 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Security.Principal;
 using System.Text;
 using System.Threading.Tasks;
 using Chickensoft.GodotEnv.Common.Clients;
@@ -145,15 +144,15 @@ public static class GodotEnv {
     IAddonsContext addonsContext,
     IGodotContext godotContext
   ) {
-    List<string> cliArgs = new();
-    List<string> commandArgs = new();
+    List<string> cliArgs = [];
+    List<string> commandArgs = [];
 
     // VSCode doesn't break apart the prompt input string
     // into multiple arguments, so we'll do that if we're being
     // debugged from VSCode.
     var preprocessedArgs = args.ToList();
     if (args.Length == 2 && args[0] is "--debug") {
-      preprocessedArgs = ReadArgs(args[1]).ToList();
+      preprocessedArgs = [.. ReadArgs(args[1])];
     }
     // ------------------------------------------------------ //
 
@@ -178,8 +177,8 @@ public static class GodotEnv {
       .InformationalVersion;
 
     return new ExecutionContext(
-      CliArgs: cliArgs.ToArray(),
-      CommandArgs: commandArgs.ToArray(),
+      CliArgs: [.. cliArgs],
+      CommandArgs: [.. commandArgs],
       Version: version,
       WorkingDir: workingDir,
       Config: config,
@@ -263,7 +262,7 @@ public static class GodotEnv {
     if (currentArg.Length > 0 || hadQuote) {
       args.Add(currentArg.ToString());
     }
-    return args.ToArray();
+    return [.. args];
   }
 }
 
@@ -333,7 +332,7 @@ public class GodotEnvActivator : ITypeActivator {
       " ",
       argsList?.Skip(1)?.Select(
         arg => (arg?.Contains(' ') ?? false) ? $"\"{arg}\"" : arg
-      )?.ToList() ?? new List<string?>()
+      )?.ToList() ?? []
     );
 
     // Rerun the godotenv command with elevation in a new window

--- a/GodotEnv/src/common/clients/EnvironmentVariableClient.cs
+++ b/GodotEnv/src/common/clients/EnvironmentVariableClient.cs
@@ -190,7 +190,7 @@ public class EnvironmentVariableClient : IEnvironmentVariableClient {
   }
 
   public bool IsShellSupported(string shellName) => FileClient.OS switch {
-    OSType.MacOS or OSType.Linux => SUPPORTED_UNIX_SHELLS.Contains(shellName.ToLower()),
+    OSType.MacOS or OSType.Linux => SUPPORTED_UNIX_SHELLS.Contains(shellName.ToLowerInvariant()),
     OSType.Windows => true,
     OSType.Unknown => false,
     _ => false,

--- a/GodotEnv/src/common/clients/FileClient.cs
+++ b/GodotEnv/src/common/clients/FileClient.cs
@@ -568,7 +568,7 @@ public class FileClient : IFileClient {
   }
 
   public List<string> ReadLines(string path) =>
-    Files.File.ReadAllLines(path).ToList();
+    [.. Files.File.ReadAllLines(path)];
 
   public void WriteLines(string path, IEnumerable<string> lines) =>
     Files.File.WriteAllLines(path, lines);

--- a/GodotEnv/src/common/clients/FileClient.cs
+++ b/GodotEnv/src/common/clients/FileClient.cs
@@ -627,10 +627,10 @@ public class FileClient : IFileClient {
     var existingLines = ReadLines(filePath);
 
     var compareLines = existingLines
-      .Select(line => line.ToLower().Trim()).ToHashSet();
+      .Select(line => line.ToLowerInvariant().Trim()).ToHashSet();
 
     var newLines = lines.Where(
-      line => !compareLines.Contains(line.ToLower().Trim())
+      line => !compareLines.Contains(line.ToLowerInvariant().Trim())
     );
 
     WriteLines(filePath, existingLines.Concat(newLines));
@@ -640,7 +640,7 @@ public class FileClient : IFileClient {
     if (!Files.File.Exists(filePath)) { return ""; }
 
     foreach (var line in ReadLines(filePath)) {
-      if (line.Trim().ToLower().StartsWith(prefix.Trim().ToLower())) {
+      if (line.Trim().StartsWith(prefix.Trim(), StringComparison.InvariantCultureIgnoreCase)) {
         return line;
       }
     }

--- a/GodotEnv/src/common/clients/ZipClientTerminal.cs
+++ b/GodotEnv/src/common/clients/ZipClientTerminal.cs
@@ -6,12 +6,11 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Chickensoft.GodotEnv.Common.Utilities;
 
-public class ZipClientTerminal : IZipClient {
+public partial class ZipClientTerminal : IZipClient {
   public IComputer Computer { get; }
   public IFileSystem Files { get; }
 
-  public static readonly Regex NumFilesRegex =
-    new(@"\s*(?<numFiles>\d+)\s+files?");
+  public static readonly Regex NumFilesRegex = numFilesRegex();
 
   public ZipClientTerminal(IComputer computer, IFileSystem files) {
     Computer = computer;
@@ -50,4 +49,7 @@ public class ZipClientTerminal : IZipClient {
 
     log.Print($"🗜 Extracted {numEntries} / {numFiles} files in {sourceArchiveFileName}.");
   }
+
+  [GeneratedRegex(@"\s*(?<numFiles>\d+)\s+files?")]
+  private static partial Regex numFilesRegex();
 }

--- a/GodotEnv/src/common/domain/ConfigFileRepository.cs
+++ b/GodotEnv/src/common/domain/ConfigFileRepository.cs
@@ -35,7 +35,7 @@ public class ConfigFileRepository : IConfigFileRepository {
   public ConfigFile LoadConfigFile(out string filename) =>
     FileClient.ReadJsonFile(
       projectPath: FileClient.AppDataDirectory,
-      possibleFilenames: new string[] { Defaults.CONFIG_FILE_NAME },
+      possibleFilenames: [Defaults.CONFIG_FILE_NAME],
       filename: out filename,
       defaultValue: new ConfigFile()
     );

--- a/GodotEnv/src/common/models/Asset.cs
+++ b/GodotEnv/src/common/models/Asset.cs
@@ -26,7 +26,7 @@ public enum AssetSource {
 /// <summary>
 /// Represents a resource accessed via a remote path, local path, or symlink.
 /// </summary>
-public interface IAsset {
+public partial interface IAsset {
   /// <summary>
   /// Asset path if <see cref="Source" /> is <see cref="AssetSource.Local" />
   /// or <see cref="AssetSource.Symlink" />. Otherwise, if
@@ -72,10 +72,10 @@ public interface IAsset {
   /// git repository url. <br />
   /// Credit: https://serverfault.com/a/917253
   /// </summary>
-  public static readonly Regex UrlRegex = new(
-    @"^((https?|ssh|git|ftps?|git\+ssh|git\+https):\/\/)?(([^\/@]+)@)?" +
-    @"([^\/:]+)[\/:]([^\/:]+)\/(.+).git\/?$"
-  );
+  public static readonly Regex UrlRegex = urlRegex();
+
+  [GeneratedRegex(@"^((https?|ssh|git|ftps?|git\+ssh|git\+https):\/\/)?(([^\/@]+)@)?([^\/:]+)[\/:]([^\/:]+)\/(.+).git\/?$")]
+  private static partial Regex urlRegex();
 }
 
 /// <summary>

--- a/GodotEnv/src/features/addons/domain/AddonsFileRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsFileRepository.cs
@@ -38,6 +38,8 @@ public interface IAddonsFileRepository {
 public class AddonsFileRepository : IAddonsFileRepository {
   public IFileClient FileClient { get; }
 
+  private static readonly string[] possibleFilenames = ["addons.json", "addons.jsonc"];
+
   public AddonsFileRepository(IFileClient fileClient) {
     FileClient = fileClient;
   }
@@ -45,7 +47,7 @@ public class AddonsFileRepository : IAddonsFileRepository {
   public AddonsFile LoadAddonsFile(string projectPath, out string filename) =>
     FileClient.ReadJsonFile(
       projectPath: projectPath,
-      possibleFilenames: new string[] { "addons.json", "addons.jsonc" },
+      possibleFilenames: possibleFilenames,
       filename: out filename,
       defaultValue: new AddonsFile()
     );

--- a/GodotEnv/src/features/addons/domain/AddonsFileRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsFileRepository.cs
@@ -38,7 +38,7 @@ public interface IAddonsFileRepository {
 public class AddonsFileRepository : IAddonsFileRepository {
   public IFileClient FileClient { get; }
 
-  private static readonly string[] possibleFilenames = ["addons.json", "addons.jsonc"];
+  private static readonly string[] _possibleFilenames = ["addons.json", "addons.jsonc"];
 
   public AddonsFileRepository(IFileClient fileClient) {
     FileClient = fileClient;
@@ -47,7 +47,7 @@ public class AddonsFileRepository : IAddonsFileRepository {
   public AddonsFile LoadAddonsFile(string projectPath, out string filename) =>
     FileClient.ReadJsonFile(
       projectPath: projectPath,
-      possibleFilenames: possibleFilenames,
+      possibleFilenames: _possibleFilenames,
       filename: out filename,
       defaultValue: new AddonsFile()
     );

--- a/GodotEnv/src/features/addons/models/Addon.cs
+++ b/GodotEnv/src/features/addons/models/Addon.cs
@@ -33,6 +33,8 @@ public record Addon : Asset, IAddon {
   /// <inheritdoc />
   public string Subfolder { get; init; }
 
+  private static readonly char[] trimChars = ['/', '\\'];
+
   /// <summary>
   /// Create a new representation of a resolved addon.
   /// </summary>
@@ -53,7 +55,7 @@ public record Addon : Asset, IAddon {
   ) : base(url, checkout, source) {
     Name = name;
     AddonsFilePath = addonsFilePath;
-    Subfolder = subfolder.Trim(new char[] { '/', '\\' });
+    Subfolder = subfolder.Trim(trimChars);
   }
 
   public override string ToString()

--- a/GodotEnv/src/features/addons/models/Addon.cs
+++ b/GodotEnv/src/features/addons/models/Addon.cs
@@ -33,7 +33,7 @@ public record Addon : Asset, IAddon {
   /// <inheritdoc />
   public string Subfolder { get; init; }
 
-  private static readonly char[] trimChars = ['/', '\\'];
+  private static readonly char[] _trimChars = ['/', '\\'];
 
   /// <summary>
   /// Create a new representation of a resolved addon.
@@ -55,7 +55,7 @@ public record Addon : Asset, IAddon {
   ) : base(url, checkout, source) {
     Name = name;
     AddonsFilePath = addonsFilePath;
-    Subfolder = subfolder.Trim(trimChars);
+    Subfolder = subfolder.Trim(_trimChars);
   }
 
   public override string ToString()

--- a/GodotEnv/src/features/godot/commands/install/GodotInstallCommand.cs
+++ b/GodotEnv/src/features/godot/commands/install/GodotInstallCommand.cs
@@ -14,7 +14,7 @@ public class GodotInstallCommand :
   [CommandParameter(
     0,
     Name = "Version",
-    Validators = new System.Type[] { typeof(GodotVersionValidator) },
+    Validators = [typeof(GodotVersionValidator)],
     Description = "Godot version to install: e.g., 4.1.0-rc.2, 4.2.0, etc." +
       " No leading 'v'. Should match a version of GodotSharp: " +
       "https://www.nuget.org/packages/GodotSharp/"

--- a/GodotEnv/src/features/godot/domain/GodotChecksumClient.cs
+++ b/GodotEnv/src/features/godot/domain/GodotChecksumClient.cs
@@ -1,4 +1,4 @@
-﻿namespace Chickensoft.GodotEnv.Features.Godot.Domain;
+namespace Chickensoft.GodotEnv.Features.Godot.Domain;
 
 using System;
 using System.Collections.Generic;
@@ -90,7 +90,7 @@ public class GodotChecksumClient(
   public async Task<string> ComputeChecksumOfArchive(GodotCompressedArchive archive) {
     using var sha512 = SHA512.Create();
     await using var filestream = File.OpenRead(Path.Join(archive.Path, archive.Filename));
-    return Convert.ToHexString(await sha512.ComputeHashAsync(filestream)).ToLower();
+    return Convert.ToHexString(await sha512.ComputeHashAsync(filestream)).ToLowerInvariant();
   }
 }
 

--- a/GodotEnv/src/features/godot/domain/GodotRepository.cs
+++ b/GodotEnv/src/features/godot/domain/GodotRepository.cs
@@ -327,8 +327,7 @@ public partial class GodotRepository : IGodotRepository {
     return archive;
   }
 
-  private async Task VerifyArchiveChecksum(ILog log, GodotCompressedArchive archive)
-  {
+  private async Task VerifyArchiveChecksum(ILog log, GodotCompressedArchive archive) {
     try {
       log.Print("⏳ Verifying Checksum");
       await ChecksumClient.VerifyArchiveChecksum(archive);
@@ -589,7 +588,7 @@ public partial class GodotRepository : IGodotRepository {
       installations.Add(installation);
     }
 
-    return installations.OrderBy(i => i.VersionName).ToList();
+    return [.. installations.OrderBy(i => i.VersionName)];
   }
 
   public async Task<List<string>> GetRemoteVersionsList() {

--- a/GodotEnv/src/features/godot/domain/GodotRepository.cs
+++ b/GodotEnv/src/features/godot/domain/GodotRepository.cs
@@ -128,7 +128,7 @@ public interface IGodotRepository {
   );
 }
 
-public class GodotRepository : IGodotRepository {
+public partial class GodotRepository : IGodotRepository {
   public ConfigFile Config { get; }
   public IFileClient FileClient { get; }
   public INetworkClient NetworkClient { get; }
@@ -171,10 +171,7 @@ public class GodotRepository : IGodotRepository {
 
   // Regex for converting directory names back into version strings to see
   // what versions we have installed.
-  public static readonly Regex DirectoryToVersionStringRegex = new(
-    @"godot_(dotnet_)?(?<major>\d+)_(?<minor>\d+)_(?<patch>\d+)_?(?<label>[a-zA-Z]+_?[\d]+)?",
-    RegexOptions.Compiled | RegexOptions.IgnoreCase
-  );
+  public static readonly Regex DirectoryToVersionStringRegex = directoryToVersionStringRegex();
 
   public GodotRepository(
     ConfigFile config,
@@ -684,4 +681,7 @@ public class GodotRepository : IGodotRepository {
     ($"godot_{(isDotnetVersion ? "dotnet_" : "")}" +
     $"{version.Major}_{version.Minor}_{version.Patch}_" +
     $"{LabelSanitized(version)}").Trim('_');
+
+  [GeneratedRegex(@"godot_(dotnet_)?(?<major>\d+)_(?<minor>\d+)_(?<patch>\d+)_?(?<label>[a-zA-Z]+_?[\d]+)?", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-US")]
+  private static partial Regex directoryToVersionStringRegex();
 }

--- a/GodotEnv/src/features/godot/models/GodotEnvironment.cs
+++ b/GodotEnv/src/features/godot/models/GodotEnvironment.cs
@@ -227,7 +227,7 @@ public abstract class GodotEnvironment : IGodotEnvironment {
       },
       dirSelector: (dirInfo) => {
         // Don't look for debug executables.
-        var name = dirInfo.Name.ToLower();
+        var name = dirInfo.Name.ToLowerInvariant();
         if (name.Contains("debug") || name.EndsWith(".lproj")) {
           return Task.FromResult(false);
         }
@@ -319,8 +319,6 @@ public abstract class GodotEnvironment : IGodotEnvironment {
   ) => GetFilenameVersionString(version) + (isDotnetVersion ? "_mono" : "") +
       "_export_templates.tpz";
 
-  private static Exception GetUnknownOSException() =>
-    new InvalidOperationException(
-      "🚨 Cannot create a platform an unknown operating system."
-    );
+  private static InvalidOperationException GetUnknownOSException() =>
+    new("🚨 Cannot create a platform an unknown operating system.");
 }

--- a/GodotEnv/src/features/godot/models/SemanticVersion.cs
+++ b/GodotEnv/src/features/godot/models/SemanticVersion.cs
@@ -3,7 +3,7 @@ namespace Chickensoft.GodotEnv.Features.Godot.Models;
 using System;
 using System.Text.RegularExpressions;
 
-public record SemanticVersion(
+public partial record SemanticVersion(
   string Major, string Minor, string Patch, string Label = ""
 ) {
   // Borrowed from https://semver.org/
@@ -13,9 +13,7 @@ public record SemanticVersion(
   /// <br />
   /// Try it: https://regex101.com/r/vkijKf/1/
   /// </summary>
-  public static Regex SemanticVersionRegex { get; } = new(
-    @"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
-  );
+  public static Regex SemanticVersionRegex { get; } = semanticVersionRegex();
 
   /// <summary>
   /// Parses a string into a semantic version model using the official
@@ -75,4 +73,7 @@ public record SemanticVersion(
 
   public override string ToString() =>
     $"Major({Major}).Minor({Minor}).Patch({Patch})-Label({Label})";
+
+  [GeneratedRegex(@"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")]
+  private static partial Regex semanticVersionRegex();
 }

--- a/GodotEnv/src/features/godot/models/Windows.cs
+++ b/GodotEnv/src/features/godot/models/Windows.cs
@@ -18,7 +18,7 @@ public class Windows : GodotEnvironment {
     isDotnetVersion ? "_mono_win64" : "_win64.exe";
 
   public override Task<bool> IsExecutable(IShell shell, IFileInfo file) =>
-    Task.FromResult(file.Name.ToLower().EndsWith(".exe"));
+    Task.FromResult(file.Name.ToLowerInvariant().EndsWith(".exe"));
 
   public override void Describe(ILog log) => log.Info("⧉ Running on Windows");
 


### PR DESCRIPTION
.NET 6.0 reaches end of support on [November 12, 2024](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). This pull request updates the projects to .NET 8.0, which is supported until November 10, 2026.

This pull request includes:

1. **Updated Target Framework**: The project has been updated from .NET 6.0 to .NET 8.0 to ensure continued support and access to the latest features and improvements.
2. **Resolved Build Warnings**: Addressed warnings introduced by the .NET 8.0 update to maintain a clean build process.
3. **Resolved IDE Code Style Warnings**: Fixed various IDE code style warnings to align with recommended practices and improve code maintainability.

Please review the changes and provide any feedback. If there are concerns about specific warnings or if any should be handled differently, such as being ignored, I’m open to suggestions.
