### PR TITLE
chore: update GitHub Actions to use Node.js 20 compatible versions

### DIFF
--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -26,10 +26,10 @@ jobs:
         shell: bash
     steps:
       - name: 🧾 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 💽 Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           # Use the .NET SDK from global.json in the root of the repository.
           global-json-file: global.json
@@ -109,10 +109,10 @@ jobs:
         shell: bash
     steps:
       - name: 🧾 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 💽 Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           # Use the .NET SDK from global.json in the root of the repository.
           global-json-file: global.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🧾 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
           submodules: 'recursive'
@@ -79,7 +79,7 @@ jobs:
         run: gh release create --generate-notes "v${{ steps.next-version.outputs.version }}"
 
       - name: 💽 Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           # Use the .NET SDK from global.json in the root of the repository.
           global-json-file: global.json

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -20,10 +20,10 @@ jobs:
         shell: bash
     steps:
       - name: 🧾 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 💽 Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           # Use the .NET SDK from global.json in the root of the repository.
           global-json-file: global.json

--- a/TestPackage/.github/workflows/auto_release.yaml
+++ b/TestPackage/.github/workflows/auto_release.yaml
@@ -31,7 +31,7 @@ jobs:
       should_release: ${{ steps.release.outputs.should_release }}
     steps:
       - name: 🧾 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🧑‍🔬 Check Test Results
         id: tests

--- a/TestPackage/.github/workflows/publish.yaml
+++ b/TestPackage/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🧾 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
           submodules: 'recursive'
@@ -76,7 +76,7 @@ jobs:
         run: gh release create --generate-notes "v${{ steps.next-version.outputs.version }}"
 
       - name: 💽 Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           # Use the .NET SDK from global.json in the root of the repository.
           global-json-file: global.json

--- a/TestPackage/.github/workflows/spellcheck.yaml
+++ b/TestPackage/.github/workflows/spellcheck.yaml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: '.'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: 🧾 Checkout
 
       - uses: streetsidesoftware/cspell-action@v2

--- a/TestPackage/.github/workflows/tests.yaml
+++ b/TestPackage/.github/workflows/tests.yaml
@@ -29,10 +29,10 @@ jobs:
         shell: bash
     steps:
       - name: 🧾 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 💽 Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           # Use the .NET SDK from global.json in the root of the repository.
           global-json-file: global.json


### PR DESCRIPTION
The following annotations are displayed for GitHub Actions.

> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-dotnet@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

`actions/checkout@v4` and `actions/setup-dotnet@v4` use Node.js 20. Updating to these versions should resolve this annotation.