### PR TITLE
fix: prevent gpg from disrupting initial commit in addon change tracking repo

### DIFF
--- a/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
@@ -370,7 +370,11 @@ public class AddonsRepositoryTest {
     cli.Runs(addonInstallPath, new ProcessResult(0), "git", "add", "-A");
     cli.Runs(
       addonInstallPath, new ProcessResult(0),
-      "git", "commit", "-m", "Initial commit"
+      "git", "config", "--local", "commit.gpgsign", "false"
+    );
+    cli.Runs(
+      addonInstallPath, new ProcessResult(0),
+      "git", "commit", "-m", "\"Initial commit\""
     );
 
     await repo.InstallAddonFromCache(addon, addon.Name);

--- a/GodotEnv/src/features/addons/domain/AddonsRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsRepository.cs
@@ -225,7 +225,10 @@ public class AddonsRepository(
     );
     await addonShell.Run("git", "add", "-A");
     await addonShell.Run(
-      "git", "commit", "-m", "Initial commit"
+      "git", "config", "--local", "commit.gpgsign", "false"
+    );
+    await addonShell.Run(
+      "git", "commit", "-m", "\"Initial commit\""
     );
   }
 


### PR DESCRIPTION
When `git config --global --get commit.gpgsign` is `true` (which GitHub documentation notes as an option when users want [to sign all commits by default in any local repository on their computer](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)), `AddonsRepository.InstallAddonFromCache(...)` fails when it attempts to run `git commit -m Initial Commit`.

This PR also changes the command from `git commit -m Initial Commit` to `git commit -m "Initial Commit"`, but this was not the cause of the issue.

Discord message link describing issue: https://discord.com/channels/862108653488963604/1020542645677867128/1279413401159860226