### PR TITLE
Add option to specify alternate addons file

### DIFF
--- a/GodotEnv.Tests/src/features/addons/commands/install/AddonsLogic.State.UnresolvedTest.cs
+++ b/GodotEnv.Tests/src/features/addons/commands/install/AddonsLogic.State.UnresolvedTest.cs
@@ -36,7 +36,7 @@ public class UnresolvedTest {
     addonsRepo.Setup(repo => repo.EnsureCacheAndAddonsDirectoriesExists());
 
     addonsFileRepo.Setup(repo => repo.LoadAddonsFile(
-      projectPath, out addonsFilePath
+      projectPath, out addonsFilePath, null
     )).Returns(addonsFile);
 
     var state = new AddonsLogic.State.Unresolved();
@@ -80,7 +80,7 @@ public class UnresolvedTest {
     addonsRepo.Setup(repo => repo.EnsureCacheAndAddonsDirectoriesExists());
 
     addonsFileRepo.Setup(repo => repo.LoadAddonsFile(
-      projectPath, out addonsFilePath
+      projectPath, out addonsFilePath, null
     )).Returns(addonsFile);
 
     addonsRepo.Setup(repo => repo.ResolveUrl(entry, addonsFilePath))
@@ -137,7 +137,7 @@ public class UnresolvedTest {
     addonsRepo.Setup(repo => repo.EnsureCacheAndAddonsDirectoriesExists());
 
     addonsFileRepo.Setup(repo => repo.LoadAddonsFile(
-      projectPath, out addonsFilePath
+      projectPath, out addonsFilePath, null
     )).Returns(addonsFile);
 
     addonsRepo.Setup(repo => repo.ResolveUrl(entry, addonsFilePath))
@@ -185,7 +185,7 @@ public class UnresolvedTest {
     var otherAddonsFilePath = "";
     addonsFileRepo
       .Setup(repo => repo.LoadAddonsFile(
-        pathToCachedAddon, out otherAddonsFilePath
+        pathToCachedAddon, out otherAddonsFilePath, null
       ))
       .Returns(otherAddonAddonsFile);
 
@@ -233,7 +233,7 @@ public class UnresolvedTest {
     addonsRepo.Setup(repo => repo.EnsureCacheAndAddonsDirectoriesExists());
 
     addonsFileRepo.Setup(repo => repo.LoadAddonsFile(
-      projectPath, out addonsFilePath
+      projectPath, out addonsFilePath, null
     )).Returns(addonsFile);
 
     addonsRepo.Setup(repo => repo.ResolveUrl(entry, addonsFilePath))
@@ -256,7 +256,7 @@ public class UnresolvedTest {
     var addonsAddonsFilePath = "";
     addonsFileRepo
       .Setup(repo => repo.LoadAddonsFile(
-        pathToCachedAddon, out addonsAddonsFilePath
+        pathToCachedAddon, out addonsAddonsFilePath, null
       )
     ).Returns(new AddonsFile());
 

--- a/GodotEnv.Tests/src/features/addons/domain/AddonsFileRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/addons/domain/AddonsFileRepositoryTest.cs
@@ -55,4 +55,32 @@ public partial class AddonsFileRepositoryTest {
       fileClient.Object.Combine(projectPath, addonsFile.CacheRelativePath)
     );
   }
+
+  [Fact]
+  public void LoadsAddonsFileWhenCalledWithAddonsFileNameArgumentShouldLoadCorrectFile() {
+    var fileClient = new Mock<IFileClient>();
+    var repo = new AddonsFileRepository(fileClient.Object);
+
+    var projectPath = "/";
+    string filename;
+    var addonsFileName = "foobar.json";
+
+    var addonsFile = new AddonsFile();
+
+    var expectedArgs = new[] { addonsFileName };
+    fileClient.Setup(client => client.ReadJsonFile(
+      projectPath,
+      It.Is<string[]>(
+        value => value.SequenceEqual(expectedArgs)
+      ),
+      out filename,
+      It.IsAny<AddonsFile>()
+    )).Returns(addonsFile);
+
+    var result = repo.LoadAddonsFile(projectPath, out filename, addonsFileName);
+
+    fileClient.VerifyAll();
+
+    result.ShouldBe(addonsFile);
+  }
 }

--- a/GodotEnv/src/features/addons/commands/install/AddonsInstallCommand.cs
+++ b/GodotEnv/src/features/addons/commands/install/AddonsInstallCommand.cs
@@ -21,6 +21,13 @@ public class AddonsInstallCommand :
   )]
   public int? MaxDepth { get; init; }
 
+  [CommandOption(
+    "addons-file-name",
+    'a',
+    Description = "The file from to from which to install addons."
+  )]
+  public string? AddonsFileName { get; init; }
+
   // If we have any top-level addons that are symlinks, we know we're going
   // to need to elevate on Windows.
   public bool IsWindowsElevationRequired =>
@@ -54,7 +61,9 @@ public class AddonsInstallCommand :
 
     var state = await logic.Input(
       new AddonsLogic.Input.Install(
-        ProjectPath: ExecutionContext.WorkingDir, MaxDepth: MaxDepth
+        ProjectPath: ExecutionContext.WorkingDir,
+        MaxDepth: MaxDepth,
+        AddonsFileName: AddonsFileName
       )
     );
 

--- a/GodotEnv/src/features/addons/commands/install/AddonsLogic.cs
+++ b/GodotEnv/src/features/addons/commands/install/AddonsLogic.cs
@@ -12,7 +12,7 @@ using Chickensoft.LogicBlocks.Generator;
 [StateMachine]
 public partial class AddonsLogic : LogicBlockAsync<AddonsLogic.State> {
   public abstract record Input {
-    public readonly record struct Install(string ProjectPath, int? MaxDepth);
+    public readonly record struct Install(string ProjectPath, int? MaxDepth, string? AddonsFileName = null);
   }
 
   public abstract record State : StateLogic {
@@ -37,7 +37,7 @@ public partial class AddonsLogic : LogicBlockAsync<AddonsLogic.State> {
         do {
           var path = searchPaths.Dequeue();
           var addonsFile = addonsFileRepo.LoadAddonsFile(
-            path, out var addonsFilePath
+            path, out var addonsFilePath, input.AddonsFileName
           );
 
           foreach ((var addonName, var addonEntry) in addonsFile.Addons) {

--- a/GodotEnv/src/features/addons/domain/AddonsFileRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsFileRepository.cs
@@ -14,8 +14,10 @@ public interface IAddonsFileRepository {
   /// <param name="projectPath">Where to search for an addons file.</param>
   /// <param name="filename">Filename that was loaded, or the first of the
   /// possible addons file names.</param>
+  /// <param name="addonsFileName">Optional path to the addons file to load.
+  /// If unspecified will load "addons.jsonc" or "addons.json". </param>
   /// <returns>Loaded addons file (or an empty one).</returns>
-  AddonsFile LoadAddonsFile(string projectPath, out string filename);
+  AddonsFile LoadAddonsFile(string projectPath, out string filename, string? addonsFileName = null);
 
   /// <summary>
   /// Creates an addons configuration object that represents the configuration
@@ -44,10 +46,10 @@ public class AddonsFileRepository : IAddonsFileRepository {
     FileClient = fileClient;
   }
 
-  public AddonsFile LoadAddonsFile(string projectPath, out string filename) =>
+  public AddonsFile LoadAddonsFile(string projectPath, out string filename, string? addonsFileName = null) =>
     FileClient.ReadJsonFile(
       projectPath: projectPath,
-      possibleFilenames: _possibleFilenames,
+      possibleFilenames: addonsFileName == null ? _possibleFilenames : [addonsFileName],
       filename: out filename,
       defaultValue: new AddonsFile()
     );


### PR DESCRIPTION
Includes a test in `AddonsFileRepositoryTest.cs`

I would like to be able to specify a separate addons file for my CI pipelines, that uses `https` instead of `ssh` in git urls. This is because locally I authenticate into GitHub using SSH, but in my CI pipeline I need to use an authentication token.

```sh
godotenv addons install --addons-file-name foodbar.jsonc
```

or

```
godotenv addons install -a foobar.jsonc
```