### PR TITLE
feat: switch remote versions source to godot-builds

### DIFF
--- a/GodotEnv.Tests/src/features/godot/domain/GodotChecksumClientTest.cs
+++ b/GodotEnv.Tests/src/features/godot/domain/GodotChecksumClientTest.cs
@@ -49,7 +49,7 @@ public class GodotChecksumClientTest {
     var networkClient = new Mock<INetworkClient>();
     networkClient.Setup(
       client => client.WebRequestGetAsync(
-        It.IsAny<string>()
+        It.IsAny<string>(), false
       ))
       .ThrowsAsync(new HttpRequestException());
 
@@ -59,7 +59,7 @@ public class GodotChecksumClientTest {
 
     await Assert.ThrowsAsync<HttpRequestException>(async () => await checksumClient.GetExpectedChecksumForArchive(archive));
 
-    networkClient.Verify(nc => nc.WebRequestGetAsync(expectedChecksumUrl), Times.Once);
+    networkClient.Verify(nc => nc.WebRequestGetAsync(expectedChecksumUrl, false), Times.Once);
   }
 
   public static IEnumerable<object[]> CorrectlyParsedJsonTestData() {
@@ -187,7 +187,7 @@ public class GodotChecksumClientTest {
     var networkClient = new Mock<INetworkClient>();
     networkClient.Setup(
         client => client.WebRequestGetAsync(
-          It.IsAny<string>()
+          It.IsAny<string>(), false
         ))
       .ReturnsAsync(() => {
         var response = new HttpResponseMessage(HttpStatusCode.OK) {

--- a/GodotEnv/src/common/clients/NetworkClient.cs
+++ b/GodotEnv/src/common/clients/NetworkClient.cs
@@ -26,7 +26,7 @@ public interface INetworkClient {
     CancellationToken token
   );
 
-  public Task<HttpResponseMessage> WebRequestGetAsync(string url);
+  public Task<HttpResponseMessage> WebRequestGetAsync(string url, bool requestAgent = false);
 }
 
 public class NetworkClient : INetworkClient {
@@ -43,9 +43,11 @@ public class NetworkClient : INetworkClient {
     DownloadConfiguration = downloadConfiguration;
   }
 
-  public async Task<HttpResponseMessage> WebRequestGetAsync(string url) {
+  public async Task<HttpResponseMessage> WebRequestGetAsync(string url, bool requestAgent = false) {
     _client ??= new HttpClient();
-
+    if (requestAgent) {
+      _client.DefaultRequestHeaders.UserAgent.TryParseAdd("request");
+    }
     return await _client.GetAsync(url);
   }
 


### PR DESCRIPTION
This update makes `godotenv godot list -r` fetch the remote versions from [godot-builds](https://github.com/godotengine/godot-builds) instead of [NuGet Package Manager](https://api.nuget.org/v3-flatcontainer/godotsharp/index.json) to get a complete list of all the official godot releases.

The GitHub API has limitations on fetching releases (30 releases per request), hence, I extract release data from the [godot-builds/releases](https://github.com/godotengine/godot-builds/tree/main/releases) folder instead of the [releases](https://github.com/godotengine/godot-builds/releases) page. This approach avoids pagination, allowing us to retrieve all 270 versions in one request instead of 9.

- [releases api request](https://api.github.com/repos/godotengine/godot-builds/releases)
- [releases page api request](https://api.github.com/repos/godotengine/godot-builds/contents/releases)


Regarding version naming, the NuGet Package Manager uses a slightly different format than the official godot naming, adding a period in tags (e.g., `dev1` becomes `dev.1`). This difference doesn’t affect installation as far as I know, as it is actually removed when fetching the zip file. The only difference would be the installation folder name, which will have one less `_`.

```nu
❯ godotenv godot list -r
Retrieving available Godot versions...
4.4.0-dev3
4.4.0-dev2
4.4.0-dev1
4.3.0-stable
4.3.0-rc3
4.3.0-rc2
...
```
Resolves #79 