### PR TITLE
Add Subfolder path check for more detailed error

### DIFF
--- a/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
@@ -480,6 +480,7 @@ public class AddonsRepositoryTest {
     var addonCachePath = CACHE_DIR + "/" + addon.Name;
     var copyFromPath = addonCachePath + "/" + addon.Subfolder;
     var addonInstallPath = ADDONS_DIR + "/" + addon.Name + "/";
+    var subfolderWithSeparatorPath = copyFromPath + "/";
 
     var cli = new ShellVerifier(addonCachePath, PROJECT_PATH, addonInstallPath);
     var subject = BuildSubject(cli: cli);
@@ -493,6 +494,8 @@ public class AddonsRepositoryTest {
 
     client.Setup(c => c.Combine(addonCachePath, addon.Subfolder))
       .Returns(copyFromPath);
+
+    client.Setup(c => c.DirectoryExists(subfolderWithSeparatorPath)).Returns(true);
 
     client.Setup(c => c.Combine(ADDONS_DIR, addon.Name))
       .Returns(addonInstallPath);
@@ -526,6 +529,25 @@ public class AddonsRepositoryTest {
 
     client.VerifyAll();
     cli.VerifyAll();
+  }
+
+  [Fact]
+  public void TestValidateSubfolderThrowsIfNoDirectory() {
+    var addon = TestData.Addon with { };
+    var addonCachePath = CACHE_DIR + "/" + addon.Name;
+    var copyFromPath = addonCachePath + "/" + addon.Subfolder;
+    var subfolderWithSeparatorPath = copyFromPath + "/";
+
+    var subject = BuildSubject();
+
+    var repo = subject.Repo;
+    var client = subject.Client;
+
+    client.Setup(c => c.DirectoryExists(subfolderWithSeparatorPath)).Returns(false);
+
+    Should.Throw<IOException>(() => repo.ValidateSubfolder(subfolderWithSeparatorPath, addon.Name));
+
+    client.VerifyAll();
   }
 
   [Fact]

--- a/GodotEnv/src/features/addons/domain/AddonsRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsRepository.cs
@@ -276,13 +276,8 @@ public class AddonsRepository(
     // https://unix.stackexchange.com/a/178095
     copyFromPath = copyFromPath.TrimEnd(FileClient.Separator) +
       FileClient.Separator;
-    // Verify that full path with subfolder exists
-    if (!FileClient.DirectoryExists(copyFromPath)) {
-      throw new IOException(
-        $"Repository folder `{copyFromPath}` does not exist in addon \"{addon.Name}\" cache." +
-        "Please ensure subfolder points to a valid folder or use `/` to copy from addon root."
-      );
-    }
+    // Perform an error check on the subfolder directory
+    ValidateSubfolder(copyFromPath, addon.Name);
     var addonInstallPath = FileClient.Combine(Config.AddonsPath, addon.Name)
       .TrimEnd(FileClient.Separator) + FileClient.Separator;
     // copy files from addon cache to addon dir, excluding git folders.
@@ -340,6 +335,16 @@ public class AddonsRepository(
     catch {
       throw new IOException(
         $"Failed to create symlink for addon \"{addon.Name}\"."
+      );
+    }
+  }
+
+  internal void ValidateSubfolder(string subfolderPath, string addonName) {
+    // Verify that full path with subfolder exists
+    if (!FileClient.DirectoryExists(subfolderPath)) {
+      throw new IOException(
+        $"Repository folder `{subfolderPath}` does not exist in addon \"{addonName}\" cache. " +
+        "Please ensure subfolder points to a valid folder or use `/` to copy from addon root."
       );
     }
   }


### PR DESCRIPTION
Following up on the discussion in #70 , this should theoretically throw a more detailed IOException error when the subfolder value points to an invalid folder, which should help with clarity in case someone (like me) uses the field incorrectly 😢 

Let me know if it looks good! 