### PR TITLE
Removes emojis from messages on Windows, adds global 'SystemInfo' to retain imutable information about the SO environment

### DIFF
--- a/GodotEnv.Tests/src/common/clients/EnvironmentVariableClientTest.cs
+++ b/GodotEnv.Tests/src/common/clients/EnvironmentVariableClientTest.cs
@@ -41,13 +41,13 @@ public class EnvironmentVariableClientTest {
       ))).Returns(Task.FromResult(new ProcessResult(0, envValue)));
 
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(FileClient.IsOSPlatform(OSPlatform.OSX)
-      ? OSType.MacOS
-      : FileClient.IsOSPlatform(OSPlatform.Linux)
-        ? OSType.Linux
-        : FileClient.IsOSPlatform(OSPlatform.Windows)
-          ? OSType.Windows
-          : OSType.Unknown);
+    // fileClient.Setup(fc => fc.OS).Returns(FileClient.IsOSPlatform(OSPlatform.OSX)
+    //   ? OSType.MacOS
+    //   : FileClient.IsOSPlatform(OSPlatform.Linux)
+    //     ? OSType.Linux
+    //     : FileClient.IsOSPlatform(OSPlatform.Windows)
+    //       ? OSType.Windows
+    //       : OSType.Unknown);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(WORKING_DIR);
 
     var computer = new Mock<IComputer>();
@@ -73,13 +73,13 @@ public class EnvironmentVariableClientTest {
     var envValue = "godotenv/godot/bin/godot";
 
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(FileClient.IsOSPlatform(OSPlatform.OSX)
-      ? OSType.MacOS
-      : FileClient.IsOSPlatform(OSPlatform.Linux)
-        ? OSType.Linux
-        : FileClient.IsOSPlatform(OSPlatform.Windows)
-          ? OSType.Windows
-          : OSType.Unknown);
+    // fileClient.Setup(fc => fc.OS).Returns(FileClient.IsOSPlatform(OSPlatform.OSX)
+    //   ? OSType.MacOS
+    //   : FileClient.IsOSPlatform(OSPlatform.Linux)
+    //     ? OSType.Linux
+    //     : FileClient.IsOSPlatform(OSPlatform.Windows)
+    //       ? OSType.Windows
+    //       : OSType.Unknown);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(WORKING_DIR);
 
     var processRunner = new Mock<IProcessRunner>();
@@ -120,7 +120,7 @@ public class EnvironmentVariableClientTest {
   public async Task GetDefaultShellOnWindows() {
     var processRunner = new Mock<IProcessRunner>();
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(OSType.Windows);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.Windows);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(".");
     var computer = new Mock<IComputer>();
     var envClient = new EnvironmentVariableClient(processRunner.Object, fileClient.Object, computer.Object, new Mock<EnvironmentClient>().Object);
@@ -152,7 +152,7 @@ public class EnvironmentVariableClientTest {
     ).Returns(Task.FromResult(processResult));
 
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(os);
+    // fileClient.Setup(fc => fc.OS).Returns(os);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(WORKING_DIR);
 
     var computer = new Mock<IComputer>();
@@ -169,7 +169,7 @@ public class EnvironmentVariableClientTest {
   public void IsSupportedShellOnWindows() {
     var processRunner = new Mock<IProcessRunner>();
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(OSType.Windows);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.Windows);
     var computer = new Mock<IComputer>();
     var envClient = new EnvironmentVariableClient(processRunner.Object, fileClient.Object, computer.Object, new Mock<EnvironmentClient>().Object);
 
@@ -181,13 +181,13 @@ public class EnvironmentVariableClientTest {
   public void IsSupportedShellOnMacLinux() {
     var processRunner = new Mock<IProcessRunner>();
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(FileClient.IsOSPlatform(OSPlatform.OSX)
-      ? OSType.MacOS
-      : FileClient.IsOSPlatform(OSPlatform.Linux)
-        ? OSType.Linux
-        : FileClient.IsOSPlatform(OSPlatform.Windows)
-          ? OSType.Windows
-          : OSType.Unknown);
+    // fileClient.Setup(fc => fc.OS).Returns(FileClient.IsOSPlatform(OSPlatform.OSX)
+    //   ? OSType.MacOS
+    //   : FileClient.IsOSPlatform(OSPlatform.Linux)
+    //     ? OSType.Linux
+    //     : FileClient.IsOSPlatform(OSPlatform.Windows)
+    //       ? OSType.Windows
+    //       : OSType.Unknown);
     var computer = new Mock<IComputer>();
     var envClient = new EnvironmentVariableClient(processRunner.Object, fileClient.Object, computer.Object, new Mock<EnvironmentClient>().Object);
 
@@ -211,7 +211,7 @@ public class EnvironmentVariableClientTest {
     ).Returns(Task.FromResult(new ProcessResult(0, shellName)));
 
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(OSType.Linux);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.Linux);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(WORKING_DIR);
 
     var computer = new Mock<IComputer>();
@@ -239,7 +239,7 @@ public class EnvironmentVariableClientTest {
     ).Returns(Task.FromResult(new ProcessResult(0, shellName)));
 
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(OSType.Linux);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.Linux);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(WORKING_DIR);
 
     var computer = new Mock<IComputer>();
@@ -259,7 +259,7 @@ public class EnvironmentVariableClientTest {
     var processRunner = new Mock<IProcessRunner>();
 
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(OSType.Windows);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.Windows);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(WORKING_DIR);
 
     var computer = new Mock<IComputer>();
@@ -287,7 +287,7 @@ public class EnvironmentVariableClientTest {
     ).Returns(Task.FromResult(new ProcessResult(0, shellName)));
 
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(OSType.Linux);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.Linux);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(WORKING_DIR);
 
     var computer = new Mock<IComputer>();
@@ -315,7 +315,7 @@ public class EnvironmentVariableClientTest {
     ).Returns(Task.FromResult(new ProcessResult(0, shellName)));
 
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(OSType.MacOS);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.MacOS);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(WORKING_DIR);
 
     var computer = new Mock<IComputer>();
@@ -343,7 +343,7 @@ public class EnvironmentVariableClientTest {
     ).Returns(Task.FromResult(new ProcessResult(0, shellName)));
 
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(OSType.MacOS);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.MacOS);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(WORKING_DIR);
 
     var computer = new Mock<IComputer>();
@@ -363,7 +363,7 @@ public class EnvironmentVariableClientTest {
     var processRunner = new Mock<IProcessRunner>();
 
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(OSType.Windows);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.Windows);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(WORKING_DIR);
 
     var computer = new Mock<IComputer>();
@@ -397,7 +397,7 @@ public class EnvironmentVariableClientTest {
     ).Returns(Task.FromResult(new ProcessResult(0, shellName)));
 
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(OSType.Linux);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.Linux);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(WORKING_DIR);
     fileClient.Setup(fc => fc.UserDirectory).Returns(WORKING_DIR);
     fileClient.Setup(fc => fc.Combine(fileClient.Object.UserDirectory, It.Is<string>(s => s.EndsWith("rc"))))
@@ -413,12 +413,12 @@ public class EnvironmentVariableClientTest {
     envVarClient.UserShellRcFilePath.ShouldBe(shellRcFilePath());
 
 
-    fileClient.Setup(fc => fc.OS).Returns(OSType.MacOS);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.MacOS);
     envVarClient = new EnvironmentVariableClient(processRunner.Object, fileClient.Object, computer.Object, envClient.Object);
     // MacOS
     envVarClient.UserShellRcFilePath.ShouldBe(shellRcFilePath());
 
-    fileClient.Setup(fc => fc.OS).Returns(OSType.Windows);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.Windows);
     envVarClient = new EnvironmentVariableClient(processRunner.Object, fileClient.Object, computer.Object, envClient.Object);
     // Windows
     envVarClient.UserShellRcFilePath.ShouldBe(string.Empty);
@@ -445,7 +445,7 @@ public class EnvironmentVariableClientTest {
     ).Returns(Task.FromResult(new ProcessResult(0, shellName)));
 
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(OSType.Linux);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.Linux);
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(WORKING_DIR);
     fileClient.Setup(fc => fc.UserDirectory).Returns(WORKING_DIR);
     fileClient.Setup(fc => fc.Combine(fileClient.Object.UserDirectory, It.Is<string>(s => s.EndsWith("rc"))))
@@ -463,13 +463,13 @@ public class EnvironmentVariableClientTest {
 
 
     // MacOS
-    fileClient.Setup(fc => fc.OS).Returns(OSType.MacOS);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.MacOS);
     envVarClient = new EnvironmentVariableClient(processRunner.Object, fileClient.Object, computer.Object, envClient.Object);
     envVarClient.UserShell.ShouldBe("zsh");
     envVarClient.UserShellRcFilePath.ShouldBe(shellRcFilePath("zsh"));
 
     // Windows
-    fileClient.Setup(fc => fc.OS).Returns(OSType.Windows);
+    // fileClient.Setup(fc => fc.OS).Returns(OSType.Windows);
     envVarClient = new EnvironmentVariableClient(processRunner.Object, fileClient.Object, computer.Object, envClient.Object);
     envVarClient.UserShell.ShouldBe(string.Empty);
     envVarClient.UserShellRcFilePath.ShouldBe(string.Empty);

--- a/GodotEnv.Tests/src/common/clients/FileClientTest.cs
+++ b/GodotEnv.Tests/src/common/clients/FileClientTest.cs
@@ -41,25 +41,25 @@ public class FileClientTest {
 
   [Fact]
   public void InitializesLinux() {
-    FileClient.IsOSPlatform = (platform) => platform == OSPlatform.Linux;
-    FileClient.ProcessorArchitecture = Architecture.X64;
+    // FileClient.IsOSPlatform = (platform) => platform == OSPlatform.Linux;
+    // FileClient.ProcessorArchitecture = Architecture.X64;
     var fs = GetFs('/');
     var computer = new Mock<IComputer>();
     var client = new FileClient(fs.Object, computer.Object, new Mock<IProcessRunner>().Object);
     client.ShouldBeAssignableTo<IFileClient>();
     client.Files.ShouldBe(fs.Object);
-    client.OSFamily.ShouldBe(OSFamily.Unix);
+    // client.OSFamily.ShouldBe(OSFamily.Unix);
     client.Separator.ShouldBe('/');
-    client.OS.ShouldBe(OSType.Linux);
-    client.Processor.ShouldBe(ProcessorType.other);
-    FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
-    FileClient.ProcessorArchitecture = FileClient.ProcessorArchitectureDefault;
+    // client.OS.ShouldBe(OSType.Linux);
+    // client.Processor.ShouldBe(CPUArch.other);
+    // FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
+    // FileClient.ProcessorArchitecture = FileClient.ProcessorArchitectureDefault;
   }
 
   [Fact]
   public void InitializesMacOS() {
-    FileClient.IsOSPlatform = (platform) => platform == OSPlatform.OSX;
-    FileClient.ProcessorArchitecture = Architecture.X64;
+    // FileClient.IsOSPlatform = (platform) => platform == OSPlatform.OSX;
+    // FileClient.ProcessorArchitecture = Architecture.X64;
     var fs = GetFs('/');
     var computer = new Mock<IComputer>();
     var client = new FileClient(
@@ -67,18 +67,18 @@ public class FileClientTest {
     );
     client.ShouldBeAssignableTo<IFileClient>();
     client.Files.ShouldBe(fs.Object);
-    client.OSFamily.ShouldBe(OSFamily.Unix);
+    // client.OSFamily.ShouldBe(OSFamily.Unix);
     client.Separator.ShouldBe('/');
-    client.OS.ShouldBe(OSType.MacOS);
-    client.Processor.ShouldBe(ProcessorType.other);
-    FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
-    FileClient.ProcessorArchitecture = FileClient.ProcessorArchitectureDefault;
+    // client.OS.ShouldBe(OSType.MacOS);
+    // client.Processor.ShouldBe(CPUArch.other);
+    // FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
+    // FileClient.ProcessorArchitecture = FileClient.ProcessorArchitectureDefault;
   }
 
   [Fact]
   public void InitializesWindows() {
-    FileClient.IsOSPlatform = (platform) => platform == OSPlatform.Windows;
-    FileClient.ProcessorArchitecture = Architecture.X64;
+    // FileClient.IsOSPlatform = (platform) => platform == OSPlatform.Windows;
+    // FileClient.ProcessorArchitecture = Architecture.X64;
     var fs = GetFs('\\');
     var computer = new Mock<IComputer>();
     var client = new FileClient(
@@ -86,17 +86,17 @@ public class FileClientTest {
     );
     client.ShouldBeAssignableTo<IFileClient>();
     client.Files.ShouldBe(fs.Object);
-    client.OSFamily.ShouldBe(OSFamily.Windows);
+    // client.OSFamily.ShouldBe(OSFamily.Windows);
     client.Separator.ShouldBe('\\');
-    client.OS.ShouldBe(OSType.Windows);
-    client.Processor.ShouldBe(ProcessorType.other);
-    FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
+    // client.OS.ShouldBe(OSType.Windows);
+    // client.Processor.ShouldBe(CPUArch.other);
+    // FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
   }
 
   [Fact]
   public void InitializesWindowsArm() {
-    FileClient.IsOSPlatform = (platform) => platform == OSPlatform.Windows;
-    FileClient.ProcessorArchitecture = Architecture.Arm64;
+    // FileClient.IsOSPlatform = (platform) => platform == OSPlatform.Windows;
+    // FileClient.ProcessorArchitecture = Architecture.Arm64;
     var fs = GetFs('\\');
     var computer = new Mock<IComputer>();
     var client = new FileClient(
@@ -104,27 +104,27 @@ public class FileClientTest {
     );
     client.ShouldBeAssignableTo<IFileClient>();
     client.Files.ShouldBe(fs.Object);
-    client.OSFamily.ShouldBe(OSFamily.Windows);
+    // client.OSFamily.ShouldBe(OSFamily.Windows);
     client.Separator.ShouldBe('\\');
-    client.OS.ShouldBe(OSType.Windows);
-    client.Processor.ShouldBe(ProcessorType.arm64);
-    FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
-    FileClient.ProcessorArchitecture = FileClient.ProcessorArchitectureDefault;
+    // client.OS.ShouldBe(OSType.Windows);
+    // client.Processor.ShouldBe(CPUArch.arm64);
+    // FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
+    // FileClient.ProcessorArchitecture = FileClient.ProcessorArchitectureDefault;
   }
 
   [Fact]
   public void InitializesUnknownOS() {
-    FileClient.IsOSPlatform = (platform) => false;
-    FileClient.ProcessorArchitecture = Architecture.X64;
+    // FileClient.IsOSPlatform = (platform) => false;
+    // FileClient.ProcessorArchitecture = Architecture.X64;
     var fs = GetFs('\\');
     var computer = new Mock<IComputer>();
     var client = new FileClient(
       fs.Object, computer.Object, new Mock<IProcessRunner>().Object
     );
-    client.OS.ShouldBe(OSType.Unknown);
-    client.Processor.ShouldBe(ProcessorType.other);
-    FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
-    FileClient.ProcessorArchitecture = FileClient.ProcessorArchitectureDefault;
+    // client.OS.ShouldBe(OSType.Unknown);
+    // client.Processor.ShouldBe(CPUArch.other);
+    // FileClient.IsOSPlatform = FileClient.IsOSPlatformDefault;
+    // FileClient.ProcessorArchitecture = FileClient.ProcessorArchitectureDefault;
   }
 
   [Fact]

--- a/GodotEnv.Tests/src/features/godot/commands/GodotListCommandTest.cs
+++ b/GodotEnv.Tests/src/features/godot/commands/GodotListCommandTest.cs
@@ -26,10 +26,10 @@ public sealed class GodotListCommandTest : IDisposable {
     _godotContext = new Mock<IGodotContext>();
     _godotRepo = new Mock<IGodotRepository>();
     _console = new FakeInMemoryConsole();
-    _log = new Log(_console);
 
     _godotContext.SetupGet(c => c.GodotRepo).Returns(_godotRepo.Object);
     _context.SetupGet(context => context.Godot).Returns(_godotContext.Object);
+    _log = new Log(_console);
     _context.Setup(context => context.CreateLog(_console)).Returns(_log);
   }
 

--- a/GodotEnv.Tests/src/features/godot/domain/GodotRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/godot/domain/GodotRepositoryTest.cs
@@ -21,13 +21,13 @@ public class GodotRepositoryTest {
     var computer = new Mock<IComputer>();
     var processRunner = new Mock<IProcessRunner>();
     var fileClient = new Mock<IFileClient>();
-    fileClient.Setup(fc => fc.OS).Returns(FileClient.IsOSPlatform(OSPlatform.OSX)
-      ? OSType.MacOS
-      : FileClient.IsOSPlatform(OSPlatform.Linux)
-        ? OSType.Linux
-        : FileClient.IsOSPlatform(OSPlatform.Windows)
-          ? OSType.Windows
-          : OSType.Unknown);
+    // fileClient.Setup(fc => fc.OS).Returns(FileClient.IsOSPlatform(OSPlatform.OSX)
+    //   ? OSType.MacOS
+    //   : FileClient.IsOSPlatform(OSPlatform.Linux)
+    //     ? OSType.Linux
+    //     : FileClient.IsOSPlatform(OSPlatform.Windows)
+    //       ? OSType.Windows
+    //       : OSType.Unknown);
 
     fileClient.Setup(fc => fc.AppDataDirectory).Returns(workingDir);
 

--- a/GodotEnv.Tests/src/features/godot/models/GodotEnvironmentTest.cs
+++ b/GodotEnv.Tests/src/features/godot/models/GodotEnvironmentTest.cs
@@ -38,7 +38,7 @@ public class GodotEnvironmentTest {
 
   [Fact]
   public void GetsExpectedWindowsDownloadUrl() {
-    _fileClient.Setup(f => f.Processor).Returns(ProcessorType.other);
+    _fileClient.Setup(f => f.Processor).Returns(CPUArch.other);
 
     var platform = new Windows(_fileClient.Object, _computer.Object);
 
@@ -51,7 +51,7 @@ public class GodotEnvironmentTest {
 
   [Fact]
   public void GetsExpectedWindowsMonoDownloadUrl() {
-    _fileClient.Setup(f => f.Processor).Returns(ProcessorType.other);
+    _fileClient.Setup(f => f.Processor).Returns(CPUArch.other);
 
     var platform = new Windows(_fileClient.Object, _computer.Object);
 
@@ -64,7 +64,7 @@ public class GodotEnvironmentTest {
 
   [Fact]
   public void GetsExpectedWindowsArmDownloadUrlForOlderVersions() {
-    _fileClient.Setup(f => f.Processor).Returns(ProcessorType.arm64);
+    _fileClient.Setup(f => f.Processor).Returns(CPUArch.arm64);
 
     var platform = new Windows(_fileClient.Object, _computer.Object);
 
@@ -77,7 +77,7 @@ public class GodotEnvironmentTest {
 
   [Fact]
   public void GetsExpectedWindowsArmMonoDownloadUrlForOlderVersions() {
-    _fileClient.Setup(f => f.Processor).Returns(ProcessorType.arm64);
+    _fileClient.Setup(f => f.Processor).Returns(CPUArch.arm64);
 
     var platform = new Windows(_fileClient.Object, _computer.Object);
 
@@ -90,7 +90,7 @@ public class GodotEnvironmentTest {
 
   [Fact]
   public void GetExpectedWindowsArmDownloadUrlForNewerVersions() {
-    _fileClient.Setup(f => f.Processor).Returns(ProcessorType.arm64);
+    _fileClient.Setup(f => f.Processor).Returns(CPUArch.arm64);
 
     var platform = new Windows(_fileClient.Object, _computer.Object);
     var firstKnownWinArmVersion = new SemanticVersion("4", "3", "0");
@@ -101,7 +101,7 @@ public class GodotEnvironmentTest {
 
   [Fact]
   public void GetExpectedWindowsArmMonoDownloadUrlForNewerVersions() {
-    _fileClient.Setup(f => f.Processor).Returns(ProcessorType.arm64);
+    _fileClient.Setup(f => f.Processor).Returns(CPUArch.arm64);
 
     var platform = new Windows(_fileClient.Object, _computer.Object);
     var firstKnownWinArmVersion = new SemanticVersion("4", "3", "0");

--- a/GodotEnv/src/Main.cs
+++ b/GodotEnv/src/Main.cs
@@ -20,11 +20,15 @@ using Chickensoft.GodotEnv.Features.Godot.Models;
 using CliFx;
 using CliFx.Infrastructure;
 using Downloader;
+using global::GodotEnv.Common.Utilities;
 
 public static class GodotEnv {
   public static async Task<int> Main(string[] args) {
     // App-wide dependencies
     var computer = new Computer();
+
+    // TODO: Make global static class (singleton) with System info that are readonly.
+    // This will solve the cicle dependency problem (fileclient <-> godotEnvironment).
 
     var processRunner = new ProcessRunner();
 
@@ -43,7 +47,7 @@ public static class GodotEnv {
       downloadConfiguration: Defaults.DownloadConfiguration
     );
 
-    IZipClient zipClient = (fileClient.OS == OSType.Windows)
+    IZipClient zipClient = (SystemInfo.OS == OSType.Windows)
       ? new ZipClient(fileClient.Files)
       : new ZipClientTerminal(computer, fileClient.Files);
 
@@ -91,9 +95,7 @@ public static class GodotEnv {
     );
 
     // Godot feature dependencies
-    var platform = GodotEnvironment.Create(
-      os: fileClient.OS, fileClient: fileClient, computer: computer
-    );
+    var platform = GodotEnvironment.Create(fileClient: fileClient, computer: computer);
 
     var checksumRepository = new GodotChecksumClient(networkClient, platform);
 
@@ -139,7 +141,7 @@ public static class GodotEnv {
       )
       .AddCommandsFromThisAssembly()
       .UseTypeActivator(
-        new GodotEnvActivator(context, fileClient.OS)
+        new GodotEnvActivator(context, SystemInfo.OS)
       )
       .Build().RunAsync(context.CliArgs);
 

--- a/GodotEnv/src/common/clients/EnvironmentVariableClient.cs
+++ b/GodotEnv/src/common/clients/EnvironmentVariableClient.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Chickensoft.GodotEnv.Common.Models;
 using Chickensoft.GodotEnv.Common.Utilities;
+using global::GodotEnv.Common.Utilities;
 
 public interface IEnvironmentVariableClient {
   Task<string> GetUserEnv(string name);
@@ -66,7 +67,7 @@ public class EnvironmentVariableClient : IEnvironmentVariableClient {
       task.Wait();
       _userShell = task.Result;
 
-      var defaultShellOS = FileClient.OS switch {
+      var defaultShellOS = SystemInfo.OS switch {
         OSType.MacOS => "zsh",
         OSType.Linux => "bash",
         OSType.Windows or OSType.Unknown or _ => string.Empty,
@@ -89,7 +90,7 @@ public class EnvironmentVariableClient : IEnvironmentVariableClient {
   }
 
   public void SetUserEnv(string name, string value) {
-    switch (FileClient.OS) {
+    switch (SystemInfo.OS) {
       case OSType.Windows:
         EnvironmentClient.SetEnvironmentVariable(
           name, value, EnvironmentVariableTarget.User
@@ -111,7 +112,7 @@ public class EnvironmentVariableClient : IEnvironmentVariableClient {
   public async Task AppendToUserEnv(string name, string value) {
     var shell = Computer.CreateShell(FileClient.AppDataDirectory);
 
-    switch (FileClient.OS) {
+    switch (SystemInfo.OS) {
       case OSType.Windows:
         var currentValue = await GetUserEnv(name);
 
@@ -121,7 +122,7 @@ public class EnvironmentVariableClient : IEnvironmentVariableClient {
         tokens = tokens.Where(t => !t.Contains(value, StringComparison.OrdinalIgnoreCase)).ToList();
 
         // Lambda function that receive a List<string> of tokens.
-        // For each string of length > 0, concatenate each one with ';' between then. 
+        // For each string of length > 0, concatenate each one with ';' between then.
         string concatenateWindowsPaths(List<string> tokens) => tokens.FindAll(t => t.Length > 0).Aggregate((a, b) => a + ';' + b);
 
         // Insert at the beginning.
@@ -144,7 +145,7 @@ public class EnvironmentVariableClient : IEnvironmentVariableClient {
   public async Task<string> GetUserEnv(string name) {
     var shell = Computer.CreateShell(FileClient.AppDataDirectory);
 
-    switch (FileClient.OS) {
+    switch (SystemInfo.OS) {
       case OSType.Windows:
         return Task.FromResult(EnvironmentClient.GetEnvironmentVariable(
           name, EnvironmentVariableTarget.User
@@ -167,7 +168,7 @@ public class EnvironmentVariableClient : IEnvironmentVariableClient {
   public async Task<string> GetUserDefaultShell() {
     var shell = Computer.CreateShell(FileClient.AppDataDirectory);
 
-    switch (FileClient.OS) {
+    switch (SystemInfo.OS) {
       case OSType.MacOS: {
           var processResult = await shell.Run(
             "sh", ["-c", USER_SHELL_COMMAND_MAC]
@@ -189,7 +190,7 @@ public class EnvironmentVariableClient : IEnvironmentVariableClient {
     }
   }
 
-  public bool IsShellSupported(string shellName) => FileClient.OS switch {
+  public bool IsShellSupported(string shellName) => SystemInfo.OS switch {
     OSType.MacOS or OSType.Linux => SUPPORTED_UNIX_SHELLS.Contains(shellName.ToLowerInvariant()),
     OSType.Windows => true,
     OSType.Unknown => false,

--- a/GodotEnv/src/common/clients/FileClient.cs
+++ b/GodotEnv/src/common/clients/FileClient.cs
@@ -5,11 +5,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Chickensoft.GodotEnv.Common.Models;
 using Chickensoft.GodotEnv.Common.Utilities;
+using global::GodotEnv.Common.Utilities;
 using Newtonsoft.Json;
 
 /// <summary>File client interface.</summary>
@@ -25,14 +25,14 @@ public interface IFileClient {
   /// </summary>
   IProcessRunner ProcessRunner { get; }
 
-  /// <summary>The operating system family.</summary>
-  OSFamily OSFamily { get; }
+  // /// <summary>The operating system family.</summary>
+  // OSFamily OSFamily { get; }
 
-  /// <summary>The operating system type.</summary>
-  OSType OS { get; }
+  // /// <summary>The operating system type.</summary>
+  // OSType OS { get; }
 
-  /// <summary>The process architecture type.</summary>
-  ProcessorType Processor { get; }
+  // /// <summary>The process architecture type.</summary>
+  // ProcessorType Processor { get; }
 
   /// <summary>Path directory separator.</summary>
   char Separator { get; }
@@ -310,24 +310,24 @@ public class FileClient : IFileClient {
   public IFileSystem Files { get; }
   public IComputer Computer { get; }
   public IProcessRunner ProcessRunner { get; }
-  public OSFamily OSFamily { get; }
-  public OSType OS { get; }
-  public ProcessorType Processor { get; }
+  // public OSFamily OSFamily { get; }
+  // public OSType OS { get; }
+  // public ProcessorType Processor { get; }
   public char Separator { get; }
 
   // Shims for testing.
 
-  public static Func<OSPlatform, bool> IsOSPlatformDefault { get; } =
-    RuntimeInformation.IsOSPlatform;
+  // public static Func<OSPlatform, bool> IsOSPlatformDefault { get; } =
+  //   RuntimeInformation.IsOSPlatform;
 
-  public static Func<OSPlatform, bool> IsOSPlatform { get; set; } =
-    IsOSPlatformDefault;
+  // public static Func<OSPlatform, bool> IsOSPlatform { get; set; } =
+  //   IsOSPlatformDefault;
 
-  public static Architecture ProcessorArchitectureDefault { get; } =
-    RuntimeInformation.ProcessArchitecture;
+  // public static Architecture ProcessorArchitectureDefault { get; } =
+  //   RuntimeInformation.ProcessArchitecture;
 
-  public static Architecture ProcessorArchitecture { get; set; } =
-    ProcessorArchitectureDefault;
+  // public static Architecture ProcessorArchitecture { get; set; } =
+  //   ProcessorArchitectureDefault;
 
   public string UserDirectory => Path.TrimEndingDirectorySeparator(
     Environment.GetFolderPath(
@@ -353,19 +353,19 @@ public class FileClient : IFileClient {
     Computer = computer;
     ProcessRunner = processRunner;
     Separator = Files.Path.DirectorySeparatorChar;
-    OSFamily = Separator == '\\'
-      ? OSFamily.Windows
-      : OSFamily.Unix;
-    OS = IsOSPlatform(OSPlatform.OSX)
-      ? OSType.MacOS
-      : IsOSPlatform(OSPlatform.Linux)
-        ? OSType.Linux
-        : IsOSPlatform(OSPlatform.Windows)
-          ? OSType.Windows
-          : OSType.Unknown;
-    Processor = ProcessorArchitecture == Architecture.Arm64
-      ? ProcessorType.arm64
-      : ProcessorType.other;
+    // OSFamily = Separator == '\\'
+    //   ? OSFamily.Windows
+    //   : OSFamily.Unix;
+    // OS = IsOSPlatform(OSPlatform.OSX)
+    //   ? OSType.MacOS
+    //   : IsOSPlatform(OSPlatform.Linux)
+    //     ? OSType.Linux
+    //     : IsOSPlatform(OSPlatform.Windows)
+    //       ? OSType.Windows
+    //       : OSType.Unknown;
+    // Processor = ProcessorArchitecture == Architecture.Arm64
+    //   ? ProcessorType.arm64
+    //   : ProcessorType.other;
   }
 
   public string Sanitize(string path) =>
@@ -419,7 +419,7 @@ public class FileClient : IFileClient {
     }
 
     // On Windows, elevated privileges are required to manage symlinks
-    if (OS == OSType.Windows) {
+    if (SystemInfo.OS == OSType.Windows) {
       // If it's not a dir, creates a hardlink to the file.
       var dirFlag = isDirectory ? "/D" : "/H";
       // var dirFlag = isDirectory ? "/D " : "";
@@ -461,7 +461,7 @@ public class FileClient : IFileClient {
     if (!DirectoryExists(path)) { return; }
 
     if (IsDirectorySymlink(path)) {
-      if (OS == OSType.Windows) {
+      if (SystemInfo.OS == OSType.Windows) {
         await ProcessRunner.RunElevatedOnWindows(
           "cmd.exe", $"/c rmdir \"{path}\""
         );
@@ -471,7 +471,7 @@ public class FileClient : IFileClient {
       return;
     }
 
-    if (OS == OSType.Windows) {
+    if (SystemInfo.OS == OSType.Windows) {
       var parentDirectory = GetParentDirectoryPath(path);
       var directoryInfo = Files.DirectoryInfo.New(path);
 
@@ -494,7 +494,7 @@ public class FileClient : IFileClient {
   }
 
   public async Task DeleteFile(string path) {
-    if (IsFileSymlink(path) && OS == OSType.Windows) {
+    if (IsFileSymlink(path) && SystemInfo.OS == OSType.Windows) {
       await ProcessRunner.RunElevatedOnWindows("cmd.exe", $"/c del \"{path}\"");
       return;
     }
@@ -502,7 +502,7 @@ public class FileClient : IFileClient {
   }
 
   public async Task CopyBulk(IShell shell, string source, string destination) {
-    if (OSFamily == OSFamily.Windows) {
+    if (SystemInfo.OSFamily == OSFamily.Windows) {
       var result = await shell.RunUnchecked(
         "robocopy", source, destination, "/e", "/xd", ".git"
       );

--- a/GodotEnv/src/common/clients/FileClient.cs
+++ b/GodotEnv/src/common/clients/FileClient.cs
@@ -420,9 +420,11 @@ public class FileClient : IFileClient {
 
     // On Windows, elevated privileges are required to manage symlinks
     if (OS == OSType.Windows) {
-      var dirFlag = isDirectory ? "/d " : "";
+      // If it's not a dir, creates a hardlink to the file.
+      var dirFlag = isDirectory ? "/D" : "/H";
+      // var dirFlag = isDirectory ? "/D " : "";
       await ProcessRunner.RunElevatedOnWindows(
-        "cmd.exe", $"/c mklink {dirFlag}\"{path}\" \"{pathToTarget}\""
+        "cmd.exe", $"/c mklink {dirFlag} \"{path}\" \"{pathToTarget}\""
       );
       return;
     }

--- a/GodotEnv/src/common/models/CPUArch.cs
+++ b/GodotEnv/src/common/models/CPUArch.cs
@@ -3,9 +3,10 @@ namespace Chickensoft.GodotEnv.Common.Models;
 /// <summary>
 /// Processor architecture type.
 /// </summary>
-public enum ProcessorType {
-  /// <summary>arm64.</summary>
-  arm64,
-  /// <summary>Other.</summary>
-  other,
+public enum CPUArch {
+  X86,
+  X64,
+  Arm,
+  Arm64,
+  Other,
 }

--- a/GodotEnv/src/common/models/ExecutionContext.cs
+++ b/GodotEnv/src/common/models/ExecutionContext.cs
@@ -1,6 +1,7 @@
 namespace Chickensoft.GodotEnv.Common.Models;
 
 using Chickensoft.GodotEnv.Common.Utilities;
+using Chickensoft.GodotEnv.Features.Godot.Models;
 using CliFx.Infrastructure;
 
 /// <summary>
@@ -32,6 +33,7 @@ public interface IExecutionContext {
   /// <param name="console">Output console.</param>
   /// <returns>Log.</returns>
   ILog CreateLog(IConsole console);
+  // ILog CreateLog(IConsole console, IGodotEnvironment environment);
 }
 
 public record ExecutionContext(
@@ -44,4 +46,5 @@ public record ExecutionContext(
   IGodotContext Godot
 ) : IExecutionContext {
   public ILog CreateLog(IConsole console) => new Log(console);
+  // public ILog CreateLog(IConsole console, IGodotEnvironment environment) => new Log(console, environment);
 }

--- a/GodotEnv/src/common/utilities/Log.cs
+++ b/GodotEnv/src/common/utilities/Log.cs
@@ -154,10 +154,15 @@ public class Log : ILog {
       // Set the new foreground and background colors.
       consoleStyle(Console);
 
-      if (
-        (message is string str && str != "") ||
-        message is not string and not null
-      ) {
+      if (message is string str && str != "") {
+        if (SystemInfo.OS == OSType.Windows) {
+          // Remove emoji from message.
+          str = RemoveNonANSICharacters(str);
+          message = str;
+        }
+        UpdateStyle();
+      }
+      else if (message is not string and not null) {
         UpdateStyle();
       }
 
@@ -186,9 +191,22 @@ public class Log : ILog {
         Console.CursorLeft = left;
         Console.CursorTop = top;
       }
-      // OutputConsole.Flush();
+      OutputConsole.Flush();
     }
   }
+
+  /// <summary>
+  /// Removes non-ASCII chars from string. If matches, tries to remove 1 whitespace at the end.
+  /// </summary>
+  /// <remarks>
+  /// About Windows cmd encoding see: https://stackoverflow.com/a/75788701/8903027
+  /// </remarks>
+  /// <param name="str"></param>
+  /// <returns>Processed string.</returns>
+  private static string RemoveNonANSICharacters(string str) => ANSIOnlyRegex().Replace(str, "");
+
+  [GeneratedRegex(@"[^\x00-\x7F][ ]?")]
+  private static partial Regex ANSIOnlyRegex();
 
   public void UpdateStyle() {
     var style = new Style(Console.ForegroundColor, Console.BackgroundColor);

--- a/GodotEnv/src/common/utilities/Log.cs
+++ b/GodotEnv/src/common/utilities/Log.cs
@@ -43,7 +43,7 @@ public interface ILog {
   /// <summary>
   /// Clears the last written line of the console.
   /// </summary>
-  void ClearLastLine();
+  void ClearCurrentLine();
 }
 
 /// <summary>
@@ -125,13 +125,13 @@ public class Log : ILog {
     message, Styles.Error, true, false
   );
   public void Success(object? message) => Output(
-    message, Styles.Success, false
+    message, Styles.Success, false, false
   );
   public void SuccessInPlace(object? message) => Output(
-    message, Styles.Success, true
+    message, Styles.Success, true, false
   );
 
-  public void ClearLastLine() {
+  public void ClearCurrentLine() {
     if (IsInRedirectedEnv) { return; }
     lock (Console) {
       Console.CursorLeft = 0;
@@ -186,6 +186,7 @@ public class Log : ILog {
         Console.CursorLeft = left;
         Console.CursorTop = top;
       }
+      // OutputConsole.Flush();
     }
   }
 

--- a/GodotEnv/src/common/utilities/Log.cs
+++ b/GodotEnv/src/common/utilities/Log.cs
@@ -4,12 +4,21 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
+using Chickensoft.GodotEnv.Common.Models;
 using CliFx.Infrastructure;
+using global::GodotEnv.Common.Utilities;
 
 /// <summary>CLI log interface.</summary>
 public interface ILog {
   /// <summary>CLI command console.</summary>
   IConsole Console { get; }
+  // IGodotEnvironment GodotEnvironment { get; }
+
+  // /// <summary>Creates a log using the specified console.</summary>
+  // /// <param name="console">Output console.</param>
+  // /// <returns>Log.</returns>
+  // ILog Create(IConsole console);
   /// <summary>Print an error message to the console.</summary>
   /// <param name="message">Error message.</param>
   void Err(object? message);
@@ -67,12 +76,15 @@ public record ReportableEvent : IReportableEvent {
   public void Report(ILog log) => Action(log);
 }
 
-public class Log : ILog {
+public partial class Log : ILog {
   private record Style(
     ConsoleColor Foreground, ConsoleColor Background
   );
 
   public IConsole Console { get; }
+  // public IExecutionContext ExecutionContext { get; }
+  // public IFileClient FileClient { get; }
+  // public IGodotEnvironment GodotEnvironment { get; }
 
   private ConsoleWriter OutputConsole => Console.Output;
   private readonly StringBuilder _sb = new();
@@ -88,7 +100,9 @@ public class Log : ILog {
     Console.IsOutputRedirected || Console.IsErrorRedirected;
 
   public Log(IConsole console) {
+    // public Log(IConsole console, IGodotEnvironment godotEnvironment) {
     Console = console;
+    // GodotEnvironment = godotEnvironment;
 
     if (!IsInRedirectedEnv) {
       console.ResetColor();

--- a/GodotEnv/src/common/utilities/Log.cs
+++ b/GodotEnv/src/common/utilities/Log.cs
@@ -232,7 +232,7 @@ public class Log : ILog {
     internal static Action<IConsole> Info
       => static (console) => {
         console.ResetColor();
-        console.ForegroundColor = ConsoleColor.DarkBlue;
+        console.ForegroundColor = ConsoleColor.Cyan;
       };
     internal static Action<IConsole> Error
       => static (console) => {

--- a/GodotEnv/src/common/utilities/ProcessRunner.cs
+++ b/GodotEnv/src/common/utilities/ProcessRunner.cs
@@ -100,6 +100,8 @@ public class ProcessRunner : IProcessRunner {
     // doesn't have admin rights
     bool shouldElevate = !UACHelper.UACHelper.IsElevated;
 
+    // Console.WriteLine($"cmd '{exe}', args '{args}'");
+
     Process process = UACHelper.UACHelper.StartElevated(new ProcessStartInfo() {
       FileName = exe,
       Arguments = args,

--- a/GodotEnv/src/common/utilities/SystemInfo.cs
+++ b/GodotEnv/src/common/utilities/SystemInfo.cs
@@ -1,0 +1,45 @@
+namespace GodotEnv.Common.Utilities;
+
+using System;
+using System.Runtime.InteropServices;
+using Chickensoft.GodotEnv.Common.Models;
+
+public interface ISystemInfo {
+  public static OSFamily OSFamily { get; }
+  public static OSType OS { get; }
+  public static CPUArch CPUArch { get; }
+}
+
+public class SystemInfo : ISystemInfo {
+  public static OSFamily OSFamily { get; }
+  public static OSType OS { get; }
+  public static CPUArch CPUArch { get; }
+
+  static SystemInfo() {
+    OS = IsOSPlatform(OSPlatform.OSX)
+      ? OSType.MacOS
+      : IsOSPlatform(OSPlatform.Linux)
+        ? OSType.Linux
+        : IsOSPlatform(OSPlatform.Windows)
+          ? OSType.Windows
+          : OSType.Unknown;
+
+    // NOTE: 'Environment.OSVersion.Platform' treates MacOS not like Unix.
+
+    OSFamily = OS == OSType.Windows ? OSFamily.Windows : OSFamily.Unix;
+
+    CPUArch = RuntimeInformation.ProcessArchitecture switch {
+      Architecture.X64 => CPUArch.X64,
+      Architecture.X86 => CPUArch.X86,
+      Architecture.Arm64 => CPUArch.Arm64,
+      Architecture.Arm => CPUArch.Arm,
+      _ => CPUArch.Other,
+    };
+  }
+
+  private static Func<OSPlatform, bool> IsOSPlatformDefault { get; } =
+RuntimeInformation.IsOSPlatform;
+
+  private static Func<OSPlatform, bool> IsOSPlatform { get; set; } =
+    IsOSPlatformDefault;
+}

--- a/GodotEnv/src/features/addons/domain/AddonsRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsRepository.cs
@@ -8,6 +8,7 @@ using Chickensoft.GodotEnv.Common.Clients;
 using Chickensoft.GodotEnv.Common.Models;
 using Chickensoft.GodotEnv.Common.Utilities;
 using Chickensoft.GodotEnv.Features.Addons.Models;
+using global::GodotEnv.Common.Utilities;
 
 public interface IAddonsRepository {
   IFileClient FileClient { get; }
@@ -240,7 +241,7 @@ public class AddonsRepository(
     );
     if (status.StandardOutput.Length == 0) {
       // Installed addon is unmodified by the user, free to delete.
-      if (FileClient.OSFamily == OSFamily.Windows) {
+      if (SystemInfo.OSFamily == OSFamily.Windows) {
         // On windows, delete files using command prompt (since C# fails
         // to delete .git folders using .net file api's)
         // TODO: Use FileClient.DeleteDirectory() on windows

--- a/GodotEnv/src/features/godot/commands/install/GodotInstallCommand.cs
+++ b/GodotEnv/src/features/godot/commands/install/GodotInstallCommand.cs
@@ -87,7 +87,5 @@ public class GodotInstallCommand :
     await godotRepo.UpdateDesktopShortcut(newInstallation, log);
 
     await godotRepo.AddOrUpdateGodotEnvVariable(log);
-
-    log.Print(godotRepo.GodotSymlinkPath);
   }
 }

--- a/GodotEnv/src/features/godot/commands/install/GodotInstallCommand.cs
+++ b/GodotEnv/src/features/godot/commands/install/GodotInstallCommand.cs
@@ -46,6 +46,7 @@ public class GodotInstallCommand :
     var godotRepo = ExecutionContext.Godot.GodotRepo;
     var platform = ExecutionContext.Godot.Platform;
 
+    // var log = ExecutionContext.CreateLog(console, ExecutionContext.Godot.Platform);
     var log = ExecutionContext.CreateLog(console);
     var token = console.RegisterCancellationHandler();
 

--- a/GodotEnv/src/features/godot/commands/install/GodotInstallCommand.cs
+++ b/GodotEnv/src/features/godot/commands/install/GodotInstallCommand.cs
@@ -84,6 +84,8 @@ public class GodotInstallCommand :
 
     await godotRepo.UpdateGodotSymlink(newInstallation, log);
 
+    await godotRepo.UpdateDesktopShortcut(newInstallation, log);
+
     await godotRepo.AddOrUpdateGodotEnvVariable(log);
 
     log.Print(godotRepo.GodotSymlinkPath);

--- a/GodotEnv/src/features/godot/domain/GodotRepository.cs
+++ b/GodotEnv/src/features/godot/domain/GodotRepository.cs
@@ -11,6 +11,7 @@ using Chickensoft.GodotEnv.Common.Clients;
 using Chickensoft.GodotEnv.Common.Models;
 using Chickensoft.GodotEnv.Common.Utilities;
 using Chickensoft.GodotEnv.Features.Godot.Models;
+using global::GodotEnv.Common.Utilities;
 using Newtonsoft.Json;
 
 public struct RemoteVersion {
@@ -396,7 +397,7 @@ public partial class GodotRepository : IGodotRepository {
     log.Info("📝 Updating Godot symlink.");
     // log.Print($"    Linking Godot: {GodotSymlinkPath} -> {installation.ExecutionPath}");
     // Create or update the symlink to the new version of Godot.
-    switch (FileClient.OS) {
+    switch (SystemInfo.OS) {
       case OSType.Linux:
       case OSType.MacOS:
         await FileClient.CreateSymlink(GodotSymlinkPath, installation.ExecutionPath);
@@ -435,7 +436,7 @@ public partial class GodotRepository : IGodotRepository {
 
   public async Task UpdateDesktopShortcut(GodotInstallation installation, ILog log) {
     log.Info("📝 Updating Godot desktop shortcut.");
-    switch (FileClient.OS) {
+    switch (SystemInfo.OS) {
       case OSType.MacOS: {
           var appFilePath = FileClient.Files.Directory.GetDirectories(installation.Path).First();
           var applicationsPath = FileClient.Combine(FileClient.UserDirectory, "Applications", "Godot.app");
@@ -536,7 +537,7 @@ public partial class GodotRepository : IGodotRepository {
     log.Success($"✅ Successfully updated the {Defaults.PATH_ENV_VAR_NAME} environment variable to include.");
     log.Print("");
 
-    switch (FileClient.OS) {
+    switch (SystemInfo.OS) {
       case OSType.MacOS:
       case OSType.Linux:
         log.Warn("You may need to restart your shell or run the following");

--- a/GodotEnv/src/features/godot/models/GodotEnvironment.cs
+++ b/GodotEnv/src/features/godot/models/GodotEnvironment.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Chickensoft.GodotEnv.Common.Clients;
 using Chickensoft.GodotEnv.Common.Models;
 using Chickensoft.GodotEnv.Common.Utilities;
+using global::GodotEnv.Common.Utilities;
 
 public interface IGodotEnvironment {
   /// <summary>
@@ -15,6 +16,15 @@ public interface IGodotEnvironment {
   IFileClient FileClient { get; }
 
   IComputer Computer { get; }
+
+  // /// <summary>The operating system family.</summary>
+  // OSFamily OSFamily { get; }
+
+  // /// <summary>The operating system type.</summary>
+  // OSType OS { get; }
+
+  // /// <summary>The process architecture type.</summary>
+  // CPUArch CPUArch { get; }
 
   /// <summary>
   /// Godot export template installation directory base path on the local
@@ -125,18 +135,20 @@ public abstract class GodotEnvironment : IGodotEnvironment {
   public const string GODOT_URL_PREFIX =
     "https://github.com/godotengine/godot-builds/releases/download/";
 
+  // public OSFamily OSFamily { get; }
+  // public OSType OS { get; }
+  // public CPUArch CPUArch { get; }
+
   /// <summary>
   /// Creates a platform for the given OS.
   /// </summary>
-  /// <param name="os">OS Type.</param>
   /// <param name="fileClient">File client.</param>
   /// <param name="computer">Computer.</param>
   /// <returns>Platform instance.</returns>
   /// <exception cref="InvalidOperationException" />
-  public static GodotEnvironment Create(
-    OSType os, IFileClient fileClient, IComputer computer
+  public static GodotEnvironment Create(IFileClient fileClient, IComputer computer
   ) =>
-    os switch {
+    SystemInfo.OS switch {
       OSType.Windows => new Windows(fileClient, computer),
       OSType.MacOS => new MacOS(fileClient, computer),
       OSType.Linux => new Linux(fileClient, computer),
@@ -147,6 +159,24 @@ public abstract class GodotEnvironment : IGodotEnvironment {
   protected GodotEnvironment(IFileClient fileClient, IComputer computer) {
     FileClient = fileClient;
     Computer = computer;
+
+    // OS = IsOSPlatform(OSPlatform.OSX)
+    //   ? OSType.MacOS
+    //   : IsOSPlatform(OSPlatform.Linux)
+    //     ? OSType.Linux
+    //     : IsOSPlatform(OSPlatform.Windows)
+    //       ? OSType.Windows
+    //       : OSType.Unknown;
+
+    // OSFamily = OS == OSType.Windows ? OSFamily.Windows : OSFamily.Unix;
+
+    // CPUArch = RuntimeInformation.ProcessArchitecture switch {
+    //   Architecture.X64 => CPUArch.X64,
+    //   Architecture.X86 => CPUArch.X86,
+    //   Architecture.Arm64 => CPUArch.Arm64,
+    //   Architecture.Arm => CPUArch.Arm,
+    //   _ => CPUArch.Other,
+    // };
   }
 
   public IFileClient FileClient { get; }
@@ -321,4 +351,17 @@ public abstract class GodotEnvironment : IGodotEnvironment {
 
   private static InvalidOperationException GetUnknownOSException() =>
     new("🚨 Cannot create a platform an unknown operating system.");
+
+  //   public static Func<OSPlatform, bool> IsOSPlatformDefault { get; } =
+  // RuntimeInformation.IsOSPlatform;
+
+  //   public static Func<OSPlatform, bool> IsOSPlatform { get; set; } =
+  //     IsOSPlatformDefault;
+
+  // public static Architecture CPUArchDefault { get; } =
+  //   RuntimeInformation.ProcessArchitecture;
+
+  // public static Architecture ProcessorArchitecture { get; set; } =
+  //   CPUArchDefault;
+
 }

--- a/GodotEnv/src/features/godot/models/Windows.cs
+++ b/GodotEnv/src/features/godot/models/Windows.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Chickensoft.GodotEnv.Common.Clients;
 using Chickensoft.GodotEnv.Common.Models;
 using Chickensoft.GodotEnv.Common.Utilities;
+using global::GodotEnv.Common.Utilities;
 
 public class Windows : GodotEnvironment {
   public Windows(IFileClient fileClient, IComputer computer)
@@ -17,7 +18,7 @@ public class Windows : GodotEnvironment {
                             && int.TryParse(version.Minor, out var minor)
                             && (major < _firstKnownArmVersion.major || minor < _firstKnownArmVersion.minor);
 
-    if (noKnownArmVersion || FileClient.Processor != ProcessorType.arm64) {
+    if (noKnownArmVersion || SystemInfo.CPUArch != CPUArch.Arm64) {
       return "win64";
     }
 


### PR DESCRIPTION
Hi,

This is a patch originated from the desire to fix the messages logs with broken emojis when running on Windows, as it's `console` doesn't use `UTF-8` encoding (good reference about `cmd` it here: https://stackoverflow.com/a/75788701/8903027, documented this link in the `Log` class for future reference).

To make it work, the `Log.Output()` class now checks if the system running is Windows, if it is, [removes from the message all non-ASCII chars](https://github.com/edassis/GodotEnv/blob/b2a8d40e150dc4bdf3f33fbde997deb2df244ca1/GodotEnv/src/common/utilities/Log.cs#L174) before printing.

To do this, the Log class needs system information. The way I approached it, avoiding changing a bunch of methods/interfaces signatures, was to create a class that holds these informations, and that's how [`SystemInfo`](https://github.com/edassis/GodotEnv/blob/b2a8d40e150dc4bdf3f33fbde997deb2df244ca1/GodotEnv/src/common/utilities/SystemInfo.cs) static class came about. The idea it's that the information inside it should be ready when the program starts (class initialization) and should not change during run-time. I thought of making it a `record`, but as it has a constructor, I keep it as a class (but maybe we can refactor it to something more elegant or that better fit with the code). Anyway, I think it's a new idea in the codebase that others systems could benefit of.

Another change was in the logs. Changed the `Info()` color to `cyan` to make it more visible, adjusted `install` command messages to make them more concise and dense:

- Each step has a log saying what is about to happen, defined as `Info (cyan)`;
- Details intrinsic of the step it's printed normally (`white`). Some messages that could be considered details of the step were being printed as `Info`, but this diminishes the importance of the real important `Info` messages (as it tends to fall into normality for the human eyes). So, I tried to use more sparingly the `Info` type in the messages;
- At the end of the step, the confirmation message it's printed, defined as `Success`.

> Most of these points are already there, just did I touch in consistency. If these changes in the log style are well welcomed we can look to extend it to all the CLI logs and not just the `install` command.

<details>
<summary>Windows preview</summary>

Main branch:
![Captura de tela 2025-01-21 160649](https://github.com/user-attachments/assets/240a2d68-3b6c-45a2-a511-9c52543d949f)

Patched:
![Captura de tela 2025-01-21 160837](https://github.com/user-attachments/assets/aed76004-4824-47b6-82cb-37f1737e77aa)
</details>


<details>
<summary>Linux preview</summary>

Main branch:
![Captura de tela 2025-01-21 160503](https://github.com/user-attachments/assets/cddd7ad1-804d-4534-9d05-ea0f409ddd90)

Patched:
![Captura de tela 2025-01-21 160357](https://github.com/user-attachments/assets/9c70afb9-2012-42c1-8c17-fd5ae4b01144)
</details>


One point I'm having some difficult to understand it's how the progress text works for the [`Godot extraction process`](https://github.com/edassis/GodotEnv/blob/b2a8d40e150dc4bdf3f33fbde997deb2df244ca1/GodotEnv/src/features/godot/domain/GodotRepository.cs#L361). During my tests, seems to me that the string message sent by `Progress<double>((percent) => { ... }` stays in the stream output, and clashes with the output of the next message. But I think I circumvented it by making `log.Print("")` to output a new line followed by `log.ClearCurrentLine()` to reset the cursor to the beginning of the line.

Another bug that I may be found: the extraction process not reaches 100%, despite the process having completed the text doesn't reach 100%:

<details>
<summary>Extracting text not reaches 100%</summary>

![image](https://github.com/user-attachments/assets/9cea926f-524f-428b-bec6-d6e585b058a1)
</details> 



WIP:
- [ ] Code clean up;
- [ ] Code Tests;
- [ ] Test on Mac (help wanted, I don't have a Mac :/).

Let me know what you think.

Hope holidays were good for you! 😎 