### PR TITLE
fix: report remote versions in consistent style

### DIFF
--- a/GodotEnv/src/features/godot/domain/GodotRepository.cs
+++ b/GodotEnv/src/features/godot/domain/GodotRepository.cs
@@ -597,18 +597,22 @@ public partial class GodotRepository : IGodotRepository {
     var versions = new List<string>();
     // format version name
     for (var i = 0; i < deserializedBody?.Count; i++) {
-      var version = deserializedBody[i];
-      version.Name = version.Name.Replace("godot-", "").Replace(".json", "");
+      var deserializedVersion = deserializedBody[i];
+      deserializedVersion.Name = deserializedVersion.Name.Replace("godot-", "").Replace(".json", "");
 
       // limit versions to godot 3 and above
-      if (version.Name[0] == '2') {
+      if (deserializedVersion.Name[0] == '2') {
         break;
       }
 
-      if (version.Name.IndexOf('.') == version.Name.LastIndexOf('.')) {
-        version.Name = version.Name.Insert(version.Name.IndexOf('-'), ".0");
+      try {
+        // Version strings coming from remote will (mostly) be in release style
+        var version = new ReleaseVersionStringConverter().ParseVersion(deserializedVersion.Name);
+        // Output in our preferred format so the user has a consistent picture of versioning
+        versions.Add(VersionStringConverter.VersionString(version));
       }
-      versions.Add(version.Name);
+      // Discard remote versions that aren't canonical, like "3.2-alpha0-unofficial"
+      catch (ArgumentException) { }
     }
 
     return versions;


### PR DESCRIPTION
The "list -r" command was reporting versions in a style that used both ".0" patch numbers a la GodotSharp, and "-stable" labels a la Godot release versioning. The resulting version strings (e.g., "4.4.0-stable") are not currently accepted by the input parser.

This change updates "list -r" to parse remote versions using release style, discard any oddball remote versions that don't conform (e.g., "3.2-alpha0-unofficial"), and show them to the user in our preferred format (which is currently Godot style, but could be updated down the line by changing IOVersionStringConverter).

Screenshot of the new behavior:
![Screenshot 2025-03-10 141239](https://github.com/user-attachments/assets/5a426626-d64d-4c4d-a3a0-5c72ba22ffcc)
