### PR TITLE
Feat: Launch selected Godot version straight from the CLI!

### DIFF
--- a/GodotEnv.Tests/src/features/godot/commands/GodotLaunchCommandTest.cs
+++ b/GodotEnv.Tests/src/features/godot/commands/GodotLaunchCommandTest.cs
@@ -1,0 +1,106 @@
+namespace Chickensoft.GodotEnv.Tests.features.godot.commands;
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Chickensoft.GodotEnv.Common.Clients;
+using Chickensoft.GodotEnv.Features.Godot.Commands;
+using Chickensoft.GodotEnv.Features.Godot.Domain;
+using Chickensoft.GodotEnv.Features.Godot.Models;
+using CliFx.Infrastructure;
+using Common.Models;
+using Common.Utilities;
+using global::GodotEnv.Common.Utilities;
+using Moq;
+using Shouldly;
+using Xunit;
+
+public sealed class GodotLaunchCommandTest : IDisposable {
+  private readonly MockSystemInfo _systemInfo;
+  private readonly Mock<IExecutionContext> _context;
+  private readonly Mock<IGodotContext> _godotContext;
+  private readonly Mock<IGodotEnvironment> _environment;
+  private readonly Mock<IGodotRepository> _godotRepo;
+  private readonly Mock<IProcessRunner> _processRunner;
+  private readonly FakeInMemoryConsole _console;
+  private readonly Mock<IFileClient> _fileClient;
+  private readonly Log _log;
+
+  public GodotLaunchCommandTest() {
+    _systemInfo = new MockSystemInfo(OSType.Linux, CPUArch.X64);
+    _context = new Mock<IExecutionContext>();
+    _godotContext = new Mock<IGodotContext>();
+    _environment = new Mock<IGodotEnvironment>();
+    _godotRepo = new Mock<IGodotRepository>();
+    _processRunner = new Mock<IProcessRunner>();
+    _console = new FakeInMemoryConsole();
+    _fileClient = new Mock<IFileClient>();
+
+
+    _environment.Setup(env => env.SystemInfo).Returns(_systemInfo);
+    _godotContext.SetupGet(c => c.GodotRepo).Returns(_godotRepo.Object);
+    _godotContext.Setup(c => c.Platform).Returns(_environment.Object);
+    _context.SetupGet(context => context.Godot).Returns(_godotContext.Object);
+    _log = new Log(_systemInfo, _console);
+    _context.Setup(context => context.CreateLog(_console)).Returns(_log);
+
+    _godotRepo.SetupGet(r => r.ProcessRunner).Returns(_processRunner.Object);
+  }
+
+  public void Dispose() {
+    _console.Dispose();
+    Environment.SetEnvironmentVariable("GODOT", null);
+  }
+
+  [Fact]
+  public async Task Launches_Godot_When_Env_Variable_Is_Valid() {
+    var godotPath = Path.Combine(Path.GetTempPath(), "godot-test-launcher");
+
+    // Create a fake Godot binary
+    File.WriteAllText(godotPath, string.Empty);
+    Environment.SetEnvironmentVariable("GODOT", godotPath);
+
+    var launchCommand = new GodotLaunchCommand(_context.Object);
+
+    await launchCommand.ExecuteAsync(_console);
+
+    _processRunner.Verify(p =>
+      p.RunDetached(godotPath, Array.Empty<string>()), Times.Once
+    );
+
+    _log.ToString().ShouldContain($"Launching Godot from {godotPath}");
+
+    // Clean up
+    File.Delete(godotPath);
+  }
+
+  [Fact]
+  public async Task Fails_When_GODOT_Variable_Is_Unset() {
+    Environment.SetEnvironmentVariable("GODOT", null);
+
+    var launchCommand = new GodotLaunchCommand(_context.Object);
+    await launchCommand.ExecuteAsync(_console);
+
+    _processRunner.Verify(p =>
+      p.RunDetached(It.IsAny<string>(), It.IsAny<string[]>()), Times.Never
+    );
+
+    _log.ToString().ShouldContain("The GODOT environment variable is not set");
+  }
+
+  [Fact]
+  public async Task Fails_When_GODOT_Target_Does_Not_Exist() {
+    var godotPath = "/nonexistent/godot";
+    Environment.SetEnvironmentVariable("GODOT", godotPath);
+
+    var launchCommand = new GodotLaunchCommand(_context.Object);
+    await launchCommand.ExecuteAsync(_console);
+
+    _processRunner.Verify(p =>
+      p.RunDetached(It.IsAny<string>(), It.IsAny<string[]>()), Times.Never
+    );
+
+    _log.ToString().ShouldContain($"The GODOT environment variable points to a missing file: {godotPath}");
+  }
+}
+

--- a/GodotEnv/src/common/utilities/ProcessRunner.cs
+++ b/GodotEnv/src/common/utilities/ProcessRunner.cs
@@ -38,6 +38,15 @@ public interface IProcessRunner {
   Task<ProcessResult> Run(string workingDir, string exe, string[] args);
 
   /// <summary>
+  /// Starts a detached process. (e.g. launching a GUI app) without waiting for it.
+  /// </summary>
+  /// <param name="args">Process arguments.
+  /// </param>
+  /// <param name="exe">Process to run (must be in the system shell's path).
+  /// </param>
+  Task RunDetached(string exe, string[] args);
+
+  /// <summary>
   /// Runs an external process with callbacks for stdout and stderr.
   /// </summary>
   /// <param name="workingDir">Working directory to run the process from.
@@ -85,6 +94,26 @@ public class ProcessRunner : IProcessRunner {
       StandardOutput: stdOutBuffer.ToString(),
       StandardError: stdErrBuffer.ToString()
     );
+  }
+
+  // This method is used to run a detached process.
+  public Task RunDetached(string exe, string[] args) {
+    var startInfo = new ProcessStartInfo {
+      FileName = exe,
+      Arguments = string.Join(" ", args),
+      UseShellExecute = true,
+      CreateNoWindow = true,
+      WorkingDirectory = Environment.CurrentDirectory
+    };
+
+    try {
+      Process.Start(startInfo);
+    }
+    catch (Exception ex) {
+      Console.Error.WriteLine($"Failed to launch detached process: {ex.Message}");
+    }
+
+    return Task.CompletedTask;
   }
 
   public async Task<ProcessResult> RunElevatedOnWindows(

--- a/GodotEnv/src/features/godot/commands/GodotLaunchCommand.cs
+++ b/GodotEnv/src/features/godot/commands/GodotLaunchCommand.cs
@@ -1,0 +1,47 @@
+namespace Chickensoft.GodotEnv.Features.Godot.Commands;
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Chickensoft.GodotEnv.Common.Clients;
+using Chickensoft.GodotEnv.Common.Models;
+using CliFx;
+using CliFx.Attributes;
+using CliFx.Infrastructure;
+using global::GodotEnv.Common.Utilities;
+
+[Command("godot launch", Description = "Launches the currently active Godot version.")]
+public class GodotLaunchCommand : ICommand, ICliCommand {
+  public IExecutionContext ExecutionContext { get; set; } = default!;
+
+  public GodotLaunchCommand(IExecutionContext context) {
+    ExecutionContext = context;
+  }
+
+  private ISystemInfo SystemInfo => ExecutionContext.Godot.Platform.SystemInfo;
+
+
+  public async ValueTask ExecuteAsync(IConsole console) {
+    var log = ExecutionContext.CreateLog(console);
+
+    string? godotPath = Environment.GetEnvironmentVariable("GODOT");
+
+    if (string.IsNullOrWhiteSpace(godotPath)) {
+      log.Err("❌ The GODOT environment variable is not set.");
+      log.Print("To set it, use:\n    godotenv godot use <version>\n");
+      return;
+    }
+
+    if (SystemInfo.OS == OSType.Windows && !godotPath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) {
+      godotPath += ".exe";
+    }
+
+    if (!File.Exists(godotPath)) {
+      log.Err($"❌ The GODOT environment variable points to a missing file: {godotPath}");
+      return;
+    }
+
+    log.Print($"🚀 Launching Godot from {godotPath}...");
+    await ExecutionContext.Godot.GodotRepo.ProcessRunner.RunDetached(godotPath, []);
+  }
+}


### PR DESCRIPTION
Heya! This is a dual Issue/Feature for GodotEnv. SymLinks aren't working the way they're supposed to on Windows, so I decided (as an avid hater of shortcuts on my beautiful wallpaper) to include a new function inside of the cli that lets you launch your selected Godot version.

I included also, a "detached" mode in the process runner so that after launching the terminal doesn't just sit and wait around due to the application being launched.

This launches the Godot executable based on the environment variable, I've only tested this on windows - but I'm fairly certain Mac and Linux should work as well. Also, I wrote a test to ensure that the command works although it gave me a LOT of headaches and I had to rely pretty heavily on AI for the test specifically, so if something doesn't look right there, that is likely why.

Let me know what you think!