### PR TITLE
fix: support old version names for existing Godot installations

### DIFF
--- a/GodotEnv.Tests/reports/branch_coverage.svg
+++ b/GodotEnv.Tests/reports/branch_coverage.svg
@@ -124,7 +124,7 @@
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
         
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">54.6%</text><text class="" x="132.5" y="14">54.6%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">56.1%</text><text class="" x="132.5" y="14">56.1%</text>
         
         
     </g>

--- a/GodotEnv.Tests/reports/line_coverage.svg
+++ b/GodotEnv.Tests/reports/line_coverage.svg
@@ -123,7 +123,7 @@
 
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">59%</text><text class="" x="132.5" y="14">59%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">60.1%</text><text class="" x="132.5" y="14">60.1%</text>
         
         
         

--- a/GodotEnv.Tests/reports/method_coverage.svg
+++ b/GodotEnv.Tests/reports/method_coverage.svg
@@ -125,7 +125,7 @@
         <text x="53" y="14" fill="#fff">Coverage</text>
         
         
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">61.6%</text><text class="" x="132.5" y="14">61.6%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">62%</text><text class="" x="132.5" y="14">62%</text>
         
     </g>
 

--- a/GodotEnv.Tests/src/features/godot/domain/GodotRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/godot/domain/GodotRepositoryTest.cs
@@ -127,10 +127,10 @@ public class GodotRepositoryTest {
     );
 
     var dotnetVersion = fileVersionDeserializer.Deserialize(godotVersionString, true)!;
-    var reconstructedDotnetVersion = godotRepo.DirectoryToVersion(godotRepo.GetVersionFsName(dotnetVersion));
+    var reconstructedDotnetVersion = godotRepo.DirectoryToVersion(godotRepo.GetVersionFsName(fileVersionSerializer, dotnetVersion));
     dotnetVersion.ShouldBe(reconstructedDotnetVersion);
     var nonDotnetVersion = fileVersionDeserializer.Deserialize(godotVersionString, false)!;
-    var reconstructedNonDotnetVersion = godotRepo.DirectoryToVersion(godotRepo.GetVersionFsName(nonDotnetVersion));
+    var reconstructedNonDotnetVersion = godotRepo.DirectoryToVersion(godotRepo.GetVersionFsName(fileVersionSerializer, nonDotnetVersion));
     nonDotnetVersion.ShouldBe(reconstructedNonDotnetVersion);
   }
 }

--- a/GodotEnv.Tests/src/features/godot/serializers/OldDiskVersionDeserializerTest.cs
+++ b/GodotEnv.Tests/src/features/godot/serializers/OldDiskVersionDeserializerTest.cs
@@ -1,0 +1,55 @@
+namespace Chickensoft.GodotEnv.Tests.Features.Godot.Models;
+
+using System;
+using System.Collections.Generic;
+using Chickensoft.GodotEnv.Features.Godot.Models;
+using Chickensoft.GodotEnv.Features.Godot.Serializers;
+using Xunit;
+
+public class OldDiskVersionDeserializerTest {
+  [Theory]
+  [InlineData("NotAVersion")]
+  [InlineData("1")]
+  [InlineData("1.")]
+  [InlineData("1.2.")]
+  [InlineData("1.2")]
+  [InlineData("1.2.3.")]
+  [InlineData("1.2.3.4.5")]
+  [InlineData("1.a")]
+  [InlineData("1.0.1-label")]
+  public void RejectionOfInvalidOldDiskVersionNumbers(string invalidVersionNumber) {
+    var deserializer = new OldDiskVersionDeserializer();
+    Assert.Throws<ArgumentException>(() => deserializer.Deserialize(invalidVersionNumber));
+  }
+
+  public static IEnumerable<object[]> CorrectDeserializationOfValidOldDiskVersionsTestData() {
+    yield return ["1.2.3-stable", new GodotVersionNumber(1, 2, 3, "stable", -1)];
+    yield return ["0.2.3-stable", new GodotVersionNumber(0, 2, 3, "stable", -1)];
+    yield return ["1.0-stable", new GodotVersionNumber(1, 0, 0, "stable", -1)];
+    yield return ["1.0.0-stable", new GodotVersionNumber(1, 0, 0, "stable", -1)];
+    yield return ["1.0-label1", new GodotVersionNumber(1, 0, 0, "label", 1)];
+    yield return ["1.0-label23", new GodotVersionNumber(1, 0, 0, "label", 23)];
+    yield return ["1.0-label.1", new GodotVersionNumber(1, 0, 0, "label", 1)];
+    yield return ["1.0-label.23", new GodotVersionNumber(1, 0, 0, "label", 23)];
+    yield return ["1.0.0-label1", new GodotVersionNumber(1, 0, 0, "label", 1)];
+    yield return ["1.0.0-label23", new GodotVersionNumber(1, 0, 0, "label", 23)];
+    yield return ["1.0.0-label.1", new GodotVersionNumber(1, 0, 0, "label", 1)];
+    yield return ["1.0.0-label.23", new GodotVersionNumber(1, 0, 0, "label", 23)];
+    yield return ["1.0.1-label23", new GodotVersionNumber(1, 0, 1, "label", 23)];
+    yield return ["1.0.1-label.23", new GodotVersionNumber(1, 0, 1, "label", 23)];
+  }
+
+  [Theory]
+  [MemberData(nameof(CorrectDeserializationOfValidOldDiskVersionsTestData))]
+  public void CorrectDeserializationOfValidOldDiskVersions(string toParse, GodotVersionNumber expectedNumber) {
+    var deserializer = new OldDiskVersionDeserializer();
+    var parsedAgnostic = deserializer.Deserialize(toParse);
+    Assert.Equal(expectedNumber, parsedAgnostic.Number);
+    var parsedDotnet = deserializer.Deserialize(toParse, true);
+    Assert.Equal(expectedNumber, parsedDotnet.Number);
+    Assert.True(parsedDotnet.IsDotnetEnabled);
+    var parsedNonDotnet = deserializer.Deserialize(toParse, false);
+    Assert.Equal(expectedNumber, parsedNonDotnet.Number);
+    Assert.False(parsedNonDotnet.IsDotnetEnabled);
+  }
+}

--- a/GodotEnv.Tests/src/features/godot/serializers/OldDiskVersionSerializerTest.cs
+++ b/GodotEnv.Tests/src/features/godot/serializers/OldDiskVersionSerializerTest.cs
@@ -1,0 +1,65 @@
+namespace Chickensoft.GodotEnv.Tests.Features.Godot.Models;
+
+using System.Collections.Generic;
+using Chickensoft.GodotEnv.Features.Godot.Models;
+using Chickensoft.GodotEnv.Features.Godot.Serializers;
+using Xunit;
+
+public class OldDiskVersionSerializerTest {
+
+  public static IEnumerable<object[]> CorrectOldDiskVersionSerializationTestData() {
+    yield return [new GodotVersionNumber(0, 0, 1, "stable", -1), true, true, true, "0.0.1-stable"];
+    yield return [new GodotVersionNumber(0, 0, 1, "stable", -1), true, true, false, "0.0.1"];
+    yield return [new GodotVersionNumber(0, 0, 1, "stable", -1), true, false, true, "0.0.1-stable"];
+    yield return [new GodotVersionNumber(0, 0, 1, "stable", -1), true, false, false, "0.0.1"];
+    yield return [new GodotVersionNumber(0, 0, 1, "stable", -1), false, true, true, "0.0.1-stable"];
+    yield return [new GodotVersionNumber(0, 0, 1, "stable", -1), false, true, false, "0.0.1"];
+    yield return [new GodotVersionNumber(0, 0, 1, "stable", -1), false, false, true, "0.0.1-stable"];
+    yield return [new GodotVersionNumber(0, 0, 1, "stable", -1), false, false, false, "0.0.1"];
+
+    yield return [new GodotVersionNumber(1, 2, 0, "stable", -1), true, true, true, "1.2.0-stable"];
+    yield return [new GodotVersionNumber(1, 2, 0, "stable", -1), true, true, false, "1.2.0"];
+    yield return [new GodotVersionNumber(1, 2, 0, "stable", -1), true, false, true, "1.2-stable"];
+    yield return [new GodotVersionNumber(1, 2, 0, "stable", -1), true, false, false, "1.2"];
+    yield return [new GodotVersionNumber(1, 2, 0, "stable", -1), false, true, true, "1.2.0-stable"];
+    yield return [new GodotVersionNumber(1, 2, 0, "stable", -1), false, true, false, "1.2.0"];
+    yield return [new GodotVersionNumber(1, 2, 0, "stable", -1), false, false, true, "1.2-stable"];
+    yield return [new GodotVersionNumber(1, 2, 0, "stable", -1), false, false, false, "1.2"];
+
+    yield return [new GodotVersionNumber(1, 2, 3, "stable", -1), true, true, true, "1.2.3-stable"];
+    yield return [new GodotVersionNumber(1, 2, 3, "stable", -1), true, true, false, "1.2.3"];
+    yield return [new GodotVersionNumber(1, 2, 3, "stable", -1), true, false, true, "1.2.3-stable"];
+    yield return [new GodotVersionNumber(1, 2, 3, "stable", -1), true, false, false, "1.2.3"];
+    yield return [new GodotVersionNumber(1, 2, 3, "stable", -1), false, true, true, "1.2.3-stable"];
+    yield return [new GodotVersionNumber(1, 2, 3, "stable", -1), false, true, false, "1.2.3"];
+    yield return [new GodotVersionNumber(1, 2, 3, "stable", -1), false, false, true, "1.2.3-stable"];
+    yield return [new GodotVersionNumber(1, 2, 3, "stable", -1), false, false, false, "1.2.3"];
+
+    yield return [new GodotVersionNumber(1, 2, 0, "label", 1), true, true, true, "1.2.0-label.1"];
+    yield return [new GodotVersionNumber(1, 2, 0, "label", 1), true, true, false, "1.2.0-label.1"];
+    yield return [new GodotVersionNumber(1, 2, 0, "label", 1), true, false, true, "1.2-label.1"];
+    yield return [new GodotVersionNumber(1, 2, 0, "label", 1), true, false, false, "1.2-label.1"];
+    yield return [new GodotVersionNumber(1, 2, 0, "label", 1), false, true, true, "1.2.0-label1"];
+    yield return [new GodotVersionNumber(1, 2, 0, "label", 1), false, true, false, "1.2.0-label1"];
+    yield return [new GodotVersionNumber(1, 2, 0, "label", 1), false, false, true, "1.2-label1"];
+    yield return [new GodotVersionNumber(1, 2, 0, "label", 1), false, false, false, "1.2-label1"];
+
+    yield return [new GodotVersionNumber(1, 2, 3, "label", 23), true, true, true, "1.2.3-label.23"];
+    yield return [new GodotVersionNumber(1, 2, 3, "label", 23), true, true, false, "1.2.3-label.23"];
+    yield return [new GodotVersionNumber(1, 2, 3, "label", 23), true, false, true, "1.2.3-label.23"];
+    yield return [new GodotVersionNumber(1, 2, 3, "label", 23), true, false, false, "1.2.3-label.23"];
+    yield return [new GodotVersionNumber(1, 2, 3, "label", 23), false, true, true, "1.2.3-label23"];
+    yield return [new GodotVersionNumber(1, 2, 3, "label", 23), false, true, false, "1.2.3-label23"];
+    yield return [new GodotVersionNumber(1, 2, 3, "label", 23), false, false, true, "1.2.3-label23"];
+    yield return [new GodotVersionNumber(1, 2, 3, "label", 23), false, false, false, "1.2.3-label23"];
+  }
+
+  [Theory]
+  [MemberData(nameof(CorrectOldDiskVersionSerializationTestData))]
+  public void CorrectOldDiskVersionSerialization(GodotVersionNumber toFormat, bool outputLabelSeparator, bool outputPatchNumber, bool outputStable, string expected) {
+    var serializer = new OldDiskVersionSerializer(outputLabelSeparator, outputPatchNumber, outputStable);
+    Assert.Equal(expected, serializer.Serialize(new AnyDotnetStatusGodotVersion(toFormat)));
+    Assert.Equal(expected, serializer.Serialize(new SpecificDotnetStatusGodotVersion(toFormat, true)));
+    Assert.Equal(expected, serializer.Serialize(new SpecificDotnetStatusGodotVersion(toFormat, false)));
+  }
+}

--- a/GodotEnv/src/features/godot/models/GodotInstallation.cs
+++ b/GodotEnv/src/features/godot/models/GodotInstallation.cs
@@ -3,28 +3,25 @@ namespace Chickensoft.GodotEnv.Features.Godot.Models;
 /// <summary>
 /// Represents a Godot installation.
 /// </summary>
-/// <param name="Name">Name of the folder containing this Godot
+/// <param name="Location">The on-disk location of this Godot
 /// installation.</param>
 /// <param name="IsActiveVersion">True if this is the active version of Godot
 /// being used by the symlink.</param>
 /// <param name="Version">Godot version with specified .NET status.</param>
-/// <param name="Path">Absolute path to the directory containing this Godot
-/// installation.</param>
 /// <param name="ExecutionPath">Fully resolved path to the Godot executable
 /// for this installation.</param>
 public record GodotInstallation(
-  string Name,
+  GodotInstallationLocation Location,
   bool IsActiveVersion,
   SpecificDotnetStatusGodotVersion Version,
-  string Path,
   string ExecutionPath
 ) {
   public override string ToString() =>
     $$"""
     "{
-      "name": {{Name}}",
+      "name": {{Location.Name}}",
       "version": "{{Version}}",
-      "path": "{{Path}}"
+      "path": "{{Location.InstallationDirectory}}"
     }
     """;
 }

--- a/GodotEnv/src/features/godot/models/GodotInstallationLocation.cs
+++ b/GodotEnv/src/features/godot/models/GodotInstallationLocation.cs
@@ -1,0 +1,12 @@
+namespace Chickensoft.GodotEnv.Features.Godot.Models;
+
+/// <summary>
+/// Represents the on-disk location of a Godot installation.
+/// </summary>
+/// <param name="Name">Name of the folder containing this Godot
+/// installation.</param>
+/// <param name="InstallationDirectory">Absolute path to the directory
+/// containing this Godot installation.</param>
+public record GodotInstallationLocation(
+  string Name, string InstallationDirectory
+);

--- a/GodotEnv/src/features/godot/serializers/OldDiskVersionDeserializer.cs
+++ b/GodotEnv/src/features/godot/serializers/OldDiskVersionDeserializer.cs
@@ -1,0 +1,54 @@
+namespace Chickensoft.GodotEnv.Features.Godot.Serializers;
+
+using System;
+using System.Text.RegularExpressions;
+using Chickensoft.GodotEnv.Features.Godot.Models;
+
+/// <summary>
+/// An <see cref="IVersionDeserializer"> for Godot installations created by
+/// pre-2.11 versions of GodotEnv.
+/// </summary>
+public partial class OldDiskVersionDeserializer : IVersionDeserializer {
+  public AnyDotnetStatusGodotVersion Deserialize(string version) =>
+    new(ParseVersionNumber(version));
+
+  public SpecificDotnetStatusGodotVersion Deserialize(string version, bool isDotnet) =>
+    new(ParseVersionNumber(version), isDotnet);
+
+  public GodotVersionNumber ParseVersionNumber(string version) {
+    var match = VersionStringRegex().Match(version);
+    if (!match.Success) {
+      throw new ArgumentException(
+        $"Couldn't match \"{version}\" to known Godot version patterns."
+      );
+    }
+    // we can safely convert major and minor, since the regex only matches
+    // digit characters
+    var major = int.Parse(match.Groups[1].Value);
+    var minor = int.Parse(match.Groups[2].Value);
+    // patch string is optional ".\d+", so we can safely convert it after
+    // the first character if it has length
+    var patch = 0;
+    var patchStr = match.Groups[3].Value;
+    if (patchStr.Length > 0) {
+      patch = int.Parse(patchStr[1..]);
+    }
+
+    var label = match.Groups[4].Value;
+    var labelNum = -1;
+    if (label != "stable") {
+      label = match.Groups[5].Value;
+      // If group 4 is not "stable", group 6 must have a positive number of
+      // digits
+      labelNum = int.Parse(match.Groups[6].Value);
+    }
+    return new GodotVersionNumber(major, minor, patch, label, labelNum);
+  }
+
+  // Version strings prior to 2.11 may or may not have a patch number
+  // and may or may not have a "." separating the label from the label number
+  // Label is either "stable" or a string followed by an optional "." and
+  // and the label number
+  [GeneratedRegex(@"^(\d+)\.(\d+)(\.\d+)?-(stable|([a-z]+)\.?(\d+))$")]
+  public static partial Regex VersionStringRegex();
+}

--- a/GodotEnv/src/features/godot/serializers/OldDiskVersionSerializer.cs
+++ b/GodotEnv/src/features/godot/serializers/OldDiskVersionSerializer.cs
@@ -1,0 +1,46 @@
+namespace Chickensoft.GodotEnv.Features.Godot.Serializers;
+
+using Chickensoft.GodotEnv.Features.Godot.Models;
+
+/// <summary>
+/// An <see cref="IVersionSerializer"> for Godot installations created by
+/// pre-2.11 versions of GodotEnv.
+/// </summary>
+public partial class OldDiskVersionSerializer : IVersionSerializer {
+  public bool OutputLabelSeparator { get; set; }
+  public bool OutputPatchNumber { get; set; }
+  public bool OutputStableLabel { get; set; }
+
+  public OldDiskVersionSerializer() { }
+
+  public OldDiskVersionSerializer(
+    bool outputLabelSeparator, bool outputPatchNumber, bool outputStableLabel
+  ) {
+    OutputLabelSeparator = outputLabelSeparator;
+    OutputPatchNumber = outputPatchNumber;
+    OutputStableLabel = outputStableLabel;
+  }
+
+  public string Serialize(GodotVersion version) {
+    var result = $"{version.Number.Major}.{version.Number.Minor}";
+    if (OutputPatchNumber || version.Number.Patch != 0) {
+      result += $".{version.Number.Patch}";
+    }
+    var label = LabelString(version);
+    if (OutputStableLabel || label != "stable") {
+      result += $"-{label}";
+    }
+    return result;
+  }
+
+  public string LabelString(GodotVersion version) {
+    var result = version.Number.Label;
+    if (result != "stable") {
+      if (OutputLabelSeparator) {
+        result += ".";
+      }
+      result += version.Number.LabelNumber;
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
Fixes #106.

Older versions (pre-2.11) of GodotEnv permitted a looser version-string specification for Godot installations:

![Screenshot 2025-04-08 152957](https://github.com/user-attachments/assets/c80476ee-e49d-4307-b602-a60cfde862aa)

These version strings would then be used for the directory name on disk where the installation was stored:

![Screenshot 2025-04-08 153010](https://github.com/user-attachments/assets/6e42900d-c4c0-449d-a09e-e7e4f1d4288b)

However, these version strings aren't compliant either with Godot versioning or GodotSharp versioning, causing #106.

This fix adds support for identifying these directories as existing Godot installations and parsing them to a compliant version number, which permits them to be listed along with newer, compliant installations:

![Screenshot 2025-04-08 153040](https://github.com/user-attachments/assets/211da556-66d7-4239-a06f-0ba529bc9017)

(The warning that the target version could not be determined is due to GodotEnv 2.10's lack of support for symlinks on Windows, fixed in #101, and can be fixed by re-issuing `godotenv godot use`):

![Screenshot 2025-04-08 153055](https://github.com/user-attachments/assets/a69cd3bd-c03d-4dc0-bf40-1e32a5503aa1)
