### PR TITLE
chore: update workflows to use windows-2025

### DIFF
--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -18,8 +18,7 @@ jobs:
       # Don't cancel other runners if one fails.
       fail-fast: false
       matrix:
-        # Also try windows-2019?
-        os: [ macos-latest, ubuntu-latest, windows-2019 ]
+        os: [ macos-latest, ubuntu-latest, windows-2025 ]
     defaults:
       run:
         # Use bash shells on all platforms.
@@ -102,8 +101,7 @@ jobs:
       # Don't cancel other runners if one fails.
       fail-fast: false
       matrix:
-        # Also try windows-2019?
-        os: [macos-latest, ubuntu-latest, windows-2019]
+        os: [macos-latest, ubuntu-latest, windows-2025]
         version: ["4.1.1", "4.4.0-beta.1", "4.0.1-stable"]
     defaults:
       run:

--- a/TestPackage/.github/workflows/tests.yaml
+++ b/TestPackage/.github/workflows/tests.yaml
@@ -16,10 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         # Put the operating systems you want to run on here.
-        #
-        # You can change windows-2019 to windows-latest, but windows-2019
-        # was running in half the time. Try it out and see what works best.
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest, windows-2025]
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_NOLOGO: true


### PR DESCRIPTION
The windows-2019 action runner is being deprecated and will be fully unsupported at the end of June: <https://github.com/actions/runner-images/issues/12045>

This PR updates the GodotEnv workflows to use windows-2025 as a replacement, as it seems to perform slightly better than windows-2022 in a completely unscientific comparison:

![Screenshot 2025-05-30 130301](https://github.com/user-attachments/assets/9f8e425b-faeb-444c-8231-890511b612f9)
(Last run of main with windows-2019 included for reference.)