### PR TITLE
feat: version-free install and use commands

### DIFF
--- a/GodotEnv.Tests/reports/line_coverage.svg
+++ b/GodotEnv.Tests/reports/line_coverage.svg
@@ -123,7 +123,7 @@
 
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">62.2%</text><text class="" x="132.5" y="14">62.2%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">62.6%</text><text class="" x="132.5" y="14">62.6%</text>
         
         
         

--- a/GodotEnv.Tests/reports/method_coverage.svg
+++ b/GodotEnv.Tests/reports/method_coverage.svg
@@ -125,7 +125,7 @@
         <text x="53" y="14" fill="#fff">Coverage</text>
         
         
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">65.9%</text><text class="" x="132.5" y="14">65.9%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">66.5%</text><text class="" x="132.5" y="14">66.5%</text>
         
     </g>
 

--- a/GodotEnv.Tests/src/features/godot/domain/GodotVersionSpecifierRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/godot/domain/GodotVersionSpecifierRepositoryTest.cs
@@ -1,0 +1,186 @@
+namespace Chickensoft.GodotEnv.Tests.Features.Config.Commands.List;
+
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using Chickensoft.GodotEnv.Common.Clients;
+using Chickensoft.GodotEnv.Common.Utilities;
+using Chickensoft.GodotEnv.Features.Godot.Domain;
+using Chickensoft.GodotEnv.Features.Godot.Models;
+using Moq;
+using Shouldly;
+using Xunit;
+
+public class GodotVersionSpecifierRepositoryTest {
+  // all global.json first, all csproj second, all godotrc third
+  // nearest ancestor to furthest ancestor
+  [Fact]
+  public void GetsVersionFilesInCorrectOrder() {
+    var directoryNames = new List<string> {
+      "/test/path/to/project",
+      "/test/path/to",
+      "/test/path",
+      "/test",
+      "/",
+    };
+    var directoryMocks = new List<Mock<IDirectoryInfo>> {
+      new(),
+      new(),
+      new(),
+      new(),
+      new(),
+    };
+    for (var i = 0; i < directoryMocks.Count; ++i) {
+      directoryMocks[i].Setup(dir => dir.FullName).Returns(directoryNames[i]);
+      if (i < directoryMocks.Count - 1) {
+        directoryMocks[i].Setup(dir => dir.Parent).Returns(directoryMocks[i + 1].Object);
+      }
+    }
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(
+        client => client.GetAncestorDirectories(directoryNames[0])
+      ).Returns(Enumerate(directoryMocks, m => m.Object));
+    fileClient.Setup(
+        client => client.Combine(It.IsAny<string[]>())
+      ).Returns((string[] s) => string.Join('/', s));
+    fileClient.Setup(
+        client => client.FileExists(It.IsAny<string>())
+      ).Returns(true);
+    fileClient.Setup(
+      client => client.GetFiles(It.IsAny<string>(), "*.csproj")
+    ).Returns((string dir, string pattern) => [$"{dir}/Project.csproj"]);
+
+    var results = new List<IGodotVersionFile>();
+    foreach (var dir in directoryNames) {
+      results.Add(new GlobalJsonFile($"{dir}/global.json"));
+    }
+    foreach (var dir in directoryNames) {
+      results.Add(new CsprojFile($"{dir}/Project.csproj"));
+    }
+    foreach (var dir in directoryNames) {
+      results.Add(new GodotrcFile($"{dir}/.godotrc"));
+    }
+
+    var repo = new GodotVersionSpecifierRepository(directoryNames[0], fileClient.Object);
+
+    repo.GetVersionFiles().ShouldBe(results);
+  }
+
+  [Fact]
+  public void ValidatedGodotVersionIsNullIfVersionIsNull() {
+    var fileClient = new Mock<IFileClient>();
+    var file = new Mock<IGodotVersionFile>();
+    SpecificDotnetStatusGodotVersion? version = null;
+    file.Setup(f => f.ParseGodotVersion(fileClient.Object)).Returns(version);
+
+    var log = new Mock<ILog>();
+
+    var repo = new GodotVersionSpecifierRepository("/test/working-dir", fileClient.Object);
+
+    repo.GetValidatedGodotVersion(file.Object, log.Object).ShouldBe(null);
+  }
+
+  [Fact]
+  public void ValidatedGodotVersionIsNullAndWarnsIfParsingThrows() {
+    var deserializationError = "bad.version is not a recognized version string";
+    var path = "/test/path";
+    var fileClient = new Mock<IFileClient>();
+
+    var file = new Mock<IGodotVersionFile>();
+    file.Setup(f => f.FilePath).Returns(path);
+    file.Setup(f => f.ParseGodotVersion(fileClient.Object))
+      .Throws(new ArgumentException(deserializationError));
+
+    var log = new Mock<ILog>();
+
+    var repo = new GodotVersionSpecifierRepository("test/working-dir", fileClient.Object);
+
+    repo.GetValidatedGodotVersion(file.Object, log.Object)
+      .ShouldBe(null);
+    log.Verify(
+      log =>
+        log.Warn($"{path} contains invalid version string; skipping")
+    );
+    log.Verify(
+      log =>
+        log.Warn(deserializationError)
+    );
+  }
+
+  [Fact]
+  public void ValidatedGodotVersionIsVersionIfVersionDeserializerReturns() {
+    var version = new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true);
+    var path = "/test/path";
+    var fileClient = new Mock<IFileClient>();
+
+    var file = new Mock<IGodotVersionFile>();
+    file.Setup(f => f.FilePath).Returns(path);
+    file.Setup(f => f.ParseGodotVersion(fileClient.Object)).Returns(version);
+
+    var log = new Mock<ILog>();
+
+    var repo = new GodotVersionSpecifierRepository("test/working-dir", fileClient.Object);
+
+    repo.GetValidatedGodotVersion(file.Object, log.Object)
+      .ShouldBe(version);
+  }
+
+  [Fact]
+  public void InfersVersionFromFirstValidVersionFile() {
+    var fileClient = new Mock<IFileClient>();
+
+    var versions = new List<SpecificDotnetStatusGodotVersion?> {
+      null,
+      new(4, 3, 0, "stable", -1, true),
+      new(4, 4, 1, "stable", -1, true),
+    };
+    var fileMocks = new List<Mock<IGodotVersionFile>> {
+      new(),
+      new(),
+      new(),
+    };
+    for (var i = 0; i < versions.Count; ++i) {
+      fileMocks[i].Setup(f => f.ParseGodotVersion(fileClient.Object)).Returns(versions[i]);
+    }
+
+    var log = new Mock<ILog>();
+
+    var repo = new GodotVersionSpecifierRepository("test/working-dir", fileClient.Object);
+
+    repo.InferVersion(Enumerate(fileMocks, m => m.Object), log.Object).ShouldBe(versions[1]);
+  }
+
+  [Fact]
+  public void InfersNoVersionIfNoValidVersionFile() {
+    var fileClient = new Mock<IFileClient>();
+
+    var versions = new List<SpecificDotnetStatusGodotVersion?> {
+      null,
+      null,
+      null,
+    };
+    var fileMocks = new List<Mock<IGodotVersionFile>> {
+      new(),
+      new(),
+      new(),
+    };
+    for (var i = 0; i < versions.Count; ++i) {
+      fileMocks[i].Setup(f => f.ParseGodotVersion(fileClient.Object)).Returns(versions[i]);
+    }
+
+    var log = new Mock<ILog>();
+
+    var repo = new GodotVersionSpecifierRepository("test/working-dir", fileClient.Object);
+
+    repo.InferVersion(Enumerate(fileMocks, m => m.Object), log.Object).ShouldBe(null);
+  }
+
+  public IEnumerable<TResult> Enumerate<TResult, TCollection>(
+    IEnumerable<TCollection> collection,
+    Func<TCollection, TResult> transform
+  ) {
+    foreach (var item in collection) {
+      yield return transform(item);
+    }
+  }
+}

--- a/GodotEnv.Tests/src/features/godot/models/CsprojFileTest.cs
+++ b/GodotEnv.Tests/src/features/godot/models/CsprojFileTest.cs
@@ -1,0 +1,186 @@
+namespace Chickensoft.GodotEnv.Tests.Features.Godot.Models;
+
+using System;
+using System.IO;
+using Chickensoft.GodotEnv.Common.Clients;
+using Chickensoft.GodotEnv.Features.Godot.Models;
+using Moq;
+using Shouldly;
+using Xunit;
+
+public class CsprojFileTest {
+  [Fact]
+  public void NewCsprojFileHasFilePath() {
+    var path = "/test/path";
+    var file = new CsprojFile(path);
+    file.FilePath.ShouldBe(path);
+  }
+
+  [Fact]
+  public void ParsedVersionIsGodotSdkIfPresent() {
+    var contents =
+        /*lang=xml,strict*/
+        """
+        <Project Sdk="Godot.NET.Sdk/4.4.1">
+          <PropertyGroup>
+            <TargetFramework>net8.0</TargetFramework>
+            <ImplicitUsings>disable</ImplicitUsings>
+            <Nullable>enable</Nullable>
+            <EnableDynamicLoading>true</EnableDynamicLoading>
+            <LangVersion>preview</LangVersion>
+            <RootNamespace>TestProject</RootNamespace>
+            <DebugType>full</DebugType>
+            <DebugSymbols>true</DebugSymbols>
+
+            <!-- Required for some nuget packages to work -->
+            <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+
+            <!-- To show generated files -->
+            <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+            <CompilerGeneratedFilesOutputPath>.generated</CompilerGeneratedFilesOutputPath>
+          </PropertyGroup>
+
+          <ItemGroup>
+            <PackageReference Include="NugetPackage" Version="1.0.0" />
+          </ItemGroup>
+
+          <ItemGroup>
+            <!-- Include the package to test. -->
+            <ProjectReference Include="../SiblingProject/SiblingProject.csproj" />
+          </ItemGroup>
+        </Project>
+        """;
+    var reader = new StringReader(contents);
+    var path = "/test/path";
+    var file = new CsprojFile(path);
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.GetReader(path)).Returns(reader);
+    var version = new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true);
+    file.ParseGodotVersion(fileClient.Object).ShouldBe(version);
+  }
+
+  [Fact]
+  public void ParsedVersionIsNullIfGodotSdkVersionUnspecified() {
+    var contents =
+        /*lang=xml,strict*/
+        """
+        <Project Sdk="Godot.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net8.0</TargetFramework>
+            <ImplicitUsings>disable</ImplicitUsings>
+            <Nullable>enable</Nullable>
+            <EnableDynamicLoading>true</EnableDynamicLoading>
+            <LangVersion>preview</LangVersion>
+            <RootNamespace>TestProject</RootNamespace>
+            <DebugType>full</DebugType>
+            <DebugSymbols>true</DebugSymbols>
+
+            <!-- Required for some nuget packages to work -->
+            <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+
+            <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+            <CompilerGeneratedFilesOutputPath>.generated</CompilerGeneratedFilesOutputPath>
+          </PropertyGroup>
+
+          <ItemGroup>
+            <!-- Test executor. -->
+            <PackageReference Include="NugetPackage" Version="1.0.0" />
+          </ItemGroup>
+
+          <ItemGroup>
+            <!-- Include the package to test. -->
+            <ProjectReference Include="../SiblingProject/SiblingProject.csproj" />
+          </ItemGroup>
+        </Project>
+        """;
+    var reader = new StringReader(contents);
+    var path = "/test/path";
+    var file = new CsprojFile(path);
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.GetReader(path)).Returns(reader);
+    file.ParseGodotVersion(fileClient.Object).ShouldBe(null);
+  }
+
+  [Fact]
+  public void ParsedVersionIsEmptyIfGodotSdkNotUsed() {
+    var contents =
+        /*lang=xml,strict*/
+        """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net8.0</TargetFramework>
+            <ImplicitUsings>disable</ImplicitUsings>
+            <Nullable>enable</Nullable>
+            <EnableDynamicLoading>true</EnableDynamicLoading>
+            <LangVersion>preview</LangVersion>
+            <RootNamespace>TestProject</RootNamespace>
+            <DebugType>full</DebugType>
+            <DebugSymbols>true</DebugSymbols>
+
+            <!-- Required for some nuget packages to work -->
+            <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+
+            <!-- To show generated files -->
+            <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+            <CompilerGeneratedFilesOutputPath>.generated</CompilerGeneratedFilesOutputPath>
+          </PropertyGroup>
+
+          <ItemGroup>
+            <PackageReference Include="NugetPackage" Version="1.0.0" />
+          </ItemGroup>
+
+          <ItemGroup>
+            <ProjectReference Include="../SiblingProject/SiblingProject.csproj" />
+          </ItemGroup>
+        </Project>
+        """;
+    var reader = new StringReader(contents);
+    var path = "/test/path";
+    var file = new CsprojFile(path);
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.GetReader(path)).Returns(reader);
+    file.ParseGodotVersion(fileClient.Object).ShouldBe(null);
+  }
+
+  [Fact]
+  public void ParseVersionThrowsIfGodotSdkVersionInvalid() {
+    var contents =
+        /*lang=xml,strict*/
+        """
+        <Project Sdk="Godot.NET.Sdk/not.a.version">
+          <PropertyGroup>
+            <TargetFramework>net8.0</TargetFramework>
+            <ImplicitUsings>disable</ImplicitUsings>
+            <Nullable>enable</Nullable>
+            <EnableDynamicLoading>true</EnableDynamicLoading>
+            <LangVersion>preview</LangVersion>
+            <RootNamespace>TestProject</RootNamespace>
+            <DebugType>full</DebugType>
+            <DebugSymbols>true</DebugSymbols>
+
+            <!-- Required for some nuget packages to work -->
+            <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+
+            <!-- To show generated files -->
+            <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+            <CompilerGeneratedFilesOutputPath>.generated</CompilerGeneratedFilesOutputPath>
+          </PropertyGroup>
+
+          <ItemGroup>
+            <PackageReference Include="NugetPackage" Version="1.0.0" />
+          </ItemGroup>
+
+          <ItemGroup>
+            <!-- Include the package to test. -->
+            <ProjectReference Include="../SiblingProject/SiblingProject.csproj" />
+          </ItemGroup>
+        </Project>
+        """;
+    var reader = new StringReader(contents);
+    var path = "/test/path";
+    var file = new CsprojFile(path);
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.GetReader(path)).Returns(reader);
+    Should.Throw<ArgumentException>(() => file.ParseGodotVersion(fileClient.Object));
+  }
+}

--- a/GodotEnv.Tests/src/features/godot/models/GlobalJsonFileTest.cs
+++ b/GodotEnv.Tests/src/features/godot/models/GlobalJsonFileTest.cs
@@ -1,0 +1,103 @@
+namespace Chickensoft.GodotEnv.Tests.Features.Godot.Models;
+
+using System;
+using System.IO;
+using Chickensoft.GodotEnv.Common.Clients;
+using Chickensoft.GodotEnv.Features.Godot.Models;
+using Moq;
+using Shouldly;
+using Xunit;
+
+public class GlobalJsonFileTest {
+  [Fact]
+  public void NewGlobalJsonFileHasFilePath() {
+    var path = "/test/path";
+    var file = new GlobalJsonFile(path);
+    file.FilePath.ShouldBe(path);
+  }
+
+  [Fact]
+  public void ParsedVersionIsGodotSdkIfPresent() {
+    var contents =
+        /*lang=json,strict*/
+        """
+        {
+          "sdk": {
+            "version": "8.0.410",
+            "rollForward": "latestMinor"
+          },
+          "msbuild-sdks": {
+            "Godot.NET.Sdk": "4.4.1"
+          }
+        }
+        """;
+    var path = "/test/path";
+    var file = new GlobalJsonFile(path);
+    using (var stream = new MemoryStream()) {
+      using (var writer = new StreamWriter(stream, leaveOpen: true)) {
+        writer.Write(contents);
+        writer.Flush();
+      }
+      stream.Position = 0;
+      var fileClient = new Mock<IFileClient>();
+      fileClient.Setup(client => client.GetReadStream(path)).Returns(stream);
+      var version = new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true);
+      file.ParseGodotVersion(fileClient.Object).ShouldBe(version);
+    }
+  }
+
+  [Fact]
+  public void ParsedVersionIsNullIfGodotSdkNotPresent() {
+    var contents =
+        /*lang=json,strict*/
+        """
+        {
+          "sdk": {
+            "version": "8.0.410",
+            "rollForward": "latestMinor"
+          }
+        }
+        """;
+    var path = "/test/path";
+    var file = new GlobalJsonFile(path);
+    using (var stream = new MemoryStream()) {
+      using (var writer = new StreamWriter(stream, leaveOpen: true)) {
+        writer.Write(contents);
+        writer.Flush();
+      }
+      stream.Position = 0;
+      var fileClient = new Mock<IFileClient>();
+      fileClient.Setup(client => client.GetReadStream(path)).Returns(stream);
+      file.ParseGodotVersion(fileClient.Object).ShouldBe(null);
+    }
+  }
+
+  [Fact]
+  public void ParseVersionThrowsIfGodotSdkVersionInvalid() {
+    var contents =
+        /*lang=json,strict*/
+        """
+        {
+          "sdk": {
+            "version": "8.0.410",
+            "rollForward": "latestMinor"
+          },
+          "msbuild-sdks": {
+            "Godot.NET.Sdk": "not.a.version"
+          }
+        }
+        """;
+    var path = "/test/path";
+    var file = new GlobalJsonFile(path);
+    using (var stream = new MemoryStream()) {
+      using (var writer = new StreamWriter(stream, leaveOpen: true)) {
+        writer.Write(contents);
+        writer.Flush();
+      }
+      stream.Position = 0;
+      var fileClient = new Mock<IFileClient>();
+      fileClient.Setup(client => client.GetReadStream(path)).Returns(stream);
+      Should.Throw<ArgumentException>(() => file.ParseGodotVersion(fileClient.Object));
+    }
+  }
+}

--- a/GodotEnv.Tests/src/features/godot/models/GodotRcFileTest.cs
+++ b/GodotEnv.Tests/src/features/godot/models/GodotRcFileTest.cs
@@ -1,0 +1,68 @@
+namespace Chickensoft.GodotEnv.Tests.Features.Godot.Models;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Chickensoft.GodotEnv.Common.Clients;
+using Chickensoft.GodotEnv.Features.Godot.Models;
+using Moq;
+using Shouldly;
+using Xunit;
+
+public class GodotRcFileTest {
+  [Fact]
+  public void NewGodotRcFileHasFilePath() {
+    var path = "/test/path";
+    var file = new GodotrcFile(path);
+    file.FilePath.ShouldBe(path);
+  }
+
+  [Fact]
+  public void ParsedVersionIsFirstLineOfFileContents() {
+    var lines = new string[] { "4.2.0", "4.3.0", "4.4.1" };
+    var lineQueue = new Queue<string>(lines);
+    var path = "/test/path";
+    var file = new GodotrcFile(path);
+    var reader = new Mock<TextReader>();
+    reader.SetupSequence(rdr => rdr.ReadLine()).Returns(lineQueue.Dequeue);
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.GetReader(path)).Returns(reader.Object);
+    var version = new SpecificDotnetStatusGodotVersion(4, 2, 0, "stable", -1, true);
+    file.ParseGodotVersion(fileClient.Object).ShouldBe(version);
+  }
+
+  [Fact]
+  public void ParsedVersionIsEmptyIfFileEmpty() {
+    var path = "/test/path";
+    var file = new GodotrcFile(path);
+    var reader = new Mock<TextReader>();
+    string? eof = null;
+    reader.Setup(rdr => rdr.ReadLine()).Returns(eof);
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.GetReader(path)).Returns(reader.Object);
+    file.ParseGodotVersion(fileClient.Object).ShouldBe(null);
+  }
+
+  [Fact]
+  public void ParsedVersionIsNotDotnetIfPrecededByTilde() {
+    var path = "/test/path";
+    var file = new GodotrcFile(path);
+    var reader = new Mock<TextReader>();
+    reader.Setup(rdr => rdr.ReadLine()).Returns("~4.2.0");
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.GetReader(path)).Returns(reader.Object);
+    var version = new SpecificDotnetStatusGodotVersion(4, 2, 0, "stable", -1, false);
+    file.ParseGodotVersion(fileClient.Object).ShouldBe(version);
+  }
+
+  [Fact]
+  public void ParseVersionThrowsIfFirstLineOfFileContentsIsNotValidVersion() {
+    var path = "/test/path";
+    var file = new GodotrcFile(path);
+    var reader = new Mock<TextReader>();
+    reader.Setup(rdr => rdr.ReadLine()).Returns("not.a.version");
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.GetReader(path)).Returns(reader.Object);
+    Should.Throw<ArgumentException>(() => file.ParseGodotVersion(fileClient.Object));
+  }
+}

--- a/GodotEnv/src/Main.cs
+++ b/GodotEnv/src/Main.cs
@@ -122,9 +122,15 @@ public static class GodotEnv {
       versionSerializer: ioVersionSerializer
     );
 
+    var versionRepo = new GodotVersionSpecifierRepository(
+      workingDir: workingDir,
+      fileClient: fileClient
+    );
+
     var godotContext = new GodotContext(
       Platform: platform,
-      GodotRepo: godotRepo
+      GodotRepo: godotRepo,
+      VersionRepo: versionRepo
     );
 
     // Create a context that contains all the information and dependencies that

--- a/GodotEnv/src/common/models/GodotContext.cs
+++ b/GodotEnv/src/common/models/GodotContext.cs
@@ -5,14 +5,18 @@ using Chickensoft.GodotEnv.Features.Godot.Models;
 
 public record GodotContext(
   IGodotEnvironment Platform,
-  IGodotRepository GodotRepo
+  IGodotRepository GodotRepo,
+  IGodotVersionSpecifierRepository VersionRepo
 ) : IGodotContext;
 
 /// <summary>Godot feature dependencies.</summary>
 public interface IGodotContext {
   /// <summary>Godot environment.</summary>
-  IGodotEnvironment Platform { get; }
+  public IGodotEnvironment Platform { get; }
 
   /// <summary>Godot installations repository.</summary>
-  IGodotRepository GodotRepo { get; }
+  public IGodotRepository GodotRepo { get; }
+
+  /// <summary>Godot version-specifying repository.</summary>
+  public IGodotVersionSpecifierRepository VersionRepo { get; }
 }

--- a/GodotEnv/src/features/godot/domain/GodotVersionSpecifierRepository.cs
+++ b/GodotEnv/src/features/godot/domain/GodotVersionSpecifierRepository.cs
@@ -1,0 +1,90 @@
+namespace Chickensoft.GodotEnv.Features.Godot.Domain;
+
+using System;
+using System.Collections.Generic;
+using Chickensoft.GodotEnv.Common.Clients;
+using Chickensoft.GodotEnv.Common.Utilities;
+using Chickensoft.GodotEnv.Features.Godot.Models;
+
+public interface IGodotVersionSpecifierRepository {
+  public string WorkingDir { get; set; }
+  public IFileClient FileClient { get; set; }
+
+  public SpecificDotnetStatusGodotVersion? InferVersion(
+    IEnumerable<IGodotVersionFile> godotVersionFiles,
+    ILog log
+  );
+  public SpecificDotnetStatusGodotVersion? GetValidatedGodotVersion(
+    IGodotVersionFile file,
+    ILog log
+  );
+  public IEnumerable<IGodotVersionFile> GetVersionFiles();
+}
+
+public class GodotVersionSpecifierRepository : IGodotVersionSpecifierRepository {
+  public string WorkingDir { get; set; }
+  public IFileClient FileClient { get; set; }
+
+  public GodotVersionSpecifierRepository(
+    string workingDir,
+    IFileClient fileClient
+  ) {
+    WorkingDir = workingDir;
+    FileClient = fileClient;
+  }
+
+  public SpecificDotnetStatusGodotVersion? InferVersion(
+    IEnumerable<IGodotVersionFile> godotVersionFiles,
+    ILog log
+  ) {
+    foreach (var godotVersionFile in godotVersionFiles) {
+      var version = GetValidatedGodotVersion(godotVersionFile, log);
+      if (version is not null) {
+        return version;
+      }
+    }
+    return null;
+  }
+
+  public SpecificDotnetStatusGodotVersion? GetValidatedGodotVersion(
+    IGodotVersionFile file,
+    ILog log
+  ) {
+    try {
+      return file.ParseGodotVersion(FileClient);
+    }
+    catch (Exception e) {
+      log.Warn($"{file.FilePath} contains invalid version string; skipping");
+      log.Warn(e.Message);
+      return null;
+    }
+  }
+
+  public IEnumerable<IGodotVersionFile> GetVersionFiles() {
+    List<GlobalJsonFile> globalJsonFiles = [];
+    List<CsprojFile> csprojFiles = [];
+    List<GodotrcFile> godotrcFiles = [];
+    foreach (var directory
+      in FileClient.GetAncestorDirectories(WorkingDir)
+    ) {
+      var globalJsonPath = FileClient.Combine(directory.FullName, "global.json");
+      if (FileClient.FileExists(globalJsonPath)) {
+        globalJsonFiles.Add(new GlobalJsonFile(globalJsonPath));
+      }
+      foreach (var csprojPath
+        in FileClient.GetFiles(directory.FullName, "*.csproj")
+      ) {
+        csprojFiles.Add(new CsprojFile(csprojPath));
+      }
+      var godotrcPath = FileClient.Combine(directory.FullName, ".godotrc");
+      if (FileClient.FileExists(godotrcPath)) {
+        godotrcFiles.Add(new GodotrcFile(godotrcPath));
+      }
+    }
+    List<IGodotVersionFile> files = [];
+    files.AddRange(globalJsonFiles);
+    files.AddRange(csprojFiles);
+    files.AddRange(godotrcFiles);
+    return files;
+  }
+}

--- a/GodotEnv/src/features/godot/models/CsprojFile.cs
+++ b/GodotEnv/src/features/godot/models/CsprojFile.cs
@@ -1,0 +1,55 @@
+namespace Chickensoft.GodotEnv.Features.Godot.Models;
+
+using System;
+using System.Xml;
+using Chickensoft.GodotEnv.Common.Clients;
+using Chickensoft.GodotEnv.Features.Godot.Serializers;
+
+public class CsprojFile : IGodotVersionFile, IEquatable<CsprojFile> {
+  private static readonly SharpVersionDeserializer _versionDeserializer = new();
+
+  /// <inheritdoc/>
+  public string FilePath { get; }
+
+  public CsprojFile(string filePath) {
+    FilePath = filePath;
+  }
+
+  /// <inheritdoc/>
+  public SpecificDotnetStatusGodotVersion? ParseGodotVersion(
+    IFileClient fileClient
+  ) {
+    var version = string.Empty;
+    try {
+      var xmlDocument = new XmlDocument();
+      using (var reader = fileClient.GetReader(FilePath)) {
+        xmlDocument.Load(reader);
+      }
+      var projectNode = xmlDocument.DocumentElement;
+      if (projectNode is null
+        || projectNode.Name != "Project"
+        || projectNode.Attributes is null
+      ) {
+        return null;
+      }
+      var sdk = projectNode.Attributes["Sdk"];
+      if (sdk is null || !sdk.Value.StartsWith("Godot.NET.Sdk/")) {
+        return null;
+      }
+      version = sdk.Value.Split('/')[1];
+    }
+    catch (Exception) {
+      return null;
+    }
+    // If the version is from a csproj, we definitely want .NET
+    return _versionDeserializer.Deserialize(version, true);
+  }
+
+  public bool Equals(CsprojFile? other) =>
+    other is not null && FilePath == other.FilePath;
+
+  public override bool Equals(object? obj) =>
+    obj is CsprojFile csprojFile && Equals(csprojFile);
+
+  public override int GetHashCode() => FilePath.GetHashCode();
+}

--- a/GodotEnv/src/features/godot/models/GlobalJsonFile.cs
+++ b/GodotEnv/src/features/godot/models/GlobalJsonFile.cs
@@ -1,0 +1,54 @@
+namespace Chickensoft.GodotEnv.Features.Godot.Models;
+
+using System;
+using System.Text.Json;
+using Chickensoft.GodotEnv.Common.Clients;
+using Chickensoft.GodotEnv.Features.Godot.Serializers;
+
+public class GlobalJsonFile : IGodotVersionFile, IEquatable<GlobalJsonFile> {
+  private static readonly SharpVersionDeserializer _versionDeserializer = new();
+
+  /// <inheritdoc/>
+  public string FilePath { get; }
+  public JsonDocumentOptions JsonDocumentOptions { get; }
+
+  public GlobalJsonFile(string filePath) {
+    FilePath = filePath;
+    JsonDocumentOptions = new() {
+      CommentHandling = JsonCommentHandling.Skip,
+      AllowTrailingCommas = true,
+    };
+  }
+
+  /// <inheritdoc/>
+  public SpecificDotnetStatusGodotVersion? ParseGodotVersion(
+    IFileClient fileClient
+  ) {
+    var version = string.Empty;
+    try {
+      using (var stream = fileClient.GetReadStream(FilePath)) {
+        using (
+          var jsonDocument = JsonDocument.Parse(stream, JsonDocumentOptions)
+        ) {
+          var msbuildSdks =
+            jsonDocument.RootElement.GetProperty("msbuild-sdks");
+          var godotSdk = msbuildSdks.GetProperty("Godot.NET.Sdk");
+          version = godotSdk.ToString();
+        }
+      }
+    }
+    catch (Exception) {
+      return null;
+    }
+    // if the version is from a global.json, we definitely want .NET
+    return _versionDeserializer.Deserialize(version, true);
+  }
+
+  public bool Equals(GlobalJsonFile? other) =>
+    other is not null && FilePath == other.FilePath;
+
+  public override bool Equals(object? obj) =>
+    obj is GlobalJsonFile globalJsonFile && Equals(globalJsonFile);
+
+  public override int GetHashCode() => FilePath.GetHashCode();
+}

--- a/GodotEnv/src/features/godot/models/GodotrcFile.cs
+++ b/GodotEnv/src/features/godot/models/GodotrcFile.cs
@@ -1,0 +1,48 @@
+namespace Chickensoft.GodotEnv.Features.Godot.Models;
+
+using System;
+using Chickensoft.GodotEnv.Common.Clients;
+using Chickensoft.GodotEnv.Features.Godot.Serializers;
+
+public class GodotrcFile : IGodotVersionFile, IEquatable<GodotrcFile> {
+  private static readonly IoVersionDeserializer _versionDeserializer = new();
+
+  /// <inheritdoc/>
+  public string FilePath { get; }
+
+  public GodotrcFile(string filePath) {
+    FilePath = filePath;
+  }
+
+  /// <inheritdoc/>
+  public SpecificDotnetStatusGodotVersion? ParseGodotVersion(
+    IFileClient fileClient
+  ) {
+    var version = string.Empty;
+    try {
+      using (var reader = fileClient.GetReader(FilePath)) {
+        version = reader.ReadLine();
+      }
+    }
+    catch (Exception) {
+      return null;
+    }
+    if (string.IsNullOrEmpty(version)) {
+      return null;
+    }
+    var isDotnet = true;
+    if (version[0] == '~') {
+      isDotnet = false;
+      version = version[1..];
+    }
+    return _versionDeserializer.Deserialize(version, isDotnet);
+  }
+
+  public bool Equals(GodotrcFile? other) =>
+    other is not null && FilePath == other.FilePath;
+
+  public override bool Equals(object? obj) =>
+    obj is GodotrcFile godotrcFile && Equals(godotrcFile);
+
+  public override int GetHashCode() => FilePath.GetHashCode();
+}

--- a/GodotEnv/src/features/godot/models/IGodotVersionFile.cs
+++ b/GodotEnv/src/features/godot/models/IGodotVersionFile.cs
@@ -1,0 +1,31 @@
+namespace Chickensoft.GodotEnv.Features.Godot.Models;
+
+using Chickensoft.GodotEnv.Common.Clients;
+
+/// <summary>
+/// Represents a file on disk that may contain a Godot version string we can use
+/// to execute a command.
+/// </summary>
+public interface IGodotVersionFile {
+  /// <summary>
+  /// The path of the file to be parsed.
+  /// </summary>
+  public string FilePath { get; }
+
+  /// <summary>
+  /// Parses and returns a Godot version from the file, if one exists.
+  /// </summary>
+  /// <param name="fileClient">
+  /// The file client to use for reading the file.
+  /// </param>
+  /// <returns>
+  /// A Godot version, if found. Null if no possible version string was found.
+  /// </returns>
+  /// <exception cref="InvalidOperationException">
+  /// If the file contained a possible Godot-version string, but it didn't
+  /// deserialize correctly.
+  /// </exception>
+  public SpecificDotnetStatusGodotVersion? ParseGodotVersion(
+    IFileClient fileClient
+  );
+}

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
     "gdenv",
     "globaltool",
     "godotenv",
+    "godotrc",
     "gpgsign",
     "imrp",
     "inheritdoc",


### PR DESCRIPTION
Fixes #81.

Enables issuing "godot install" and "godot use" without a version parameter. If no version parameter is provided, the command will walk up the directory tree in search of files named "global.json", "*.csproj", and ".godotrc". A global.json at any directory level will be preferred to any csproj, and a csproj at any directory level will be preferred to any .godotrc. A file closer to the working directory will be preferred to one of the same type further up the tree. The first file according to this ordering scheme that contains a valid Godot version will be used to infer the version for the command.

.godotrc files must contain a valid version string, either in GodotSharp style or in Godot release style, as their first line.

Versions from global.json files or csproj files must be in GodotSharp style and are assumed to specify .NET versions of Godot. A .godotrc file may specify a non-.NET version by preceding the version string with a tilde (~) character:
```
~4.3.0
```

Both commands will print an error if invoked without a version argument and no version-specifying file exists in the directory hierarchy:
![install-no-file](https://github.com/user-attachments/assets/aed46a0c-3bdf-43ae-981f-cf5748f1b63f)

Both commands will warn the user if a version-specifying file containing an unparseable version string exists in the directory hierarchy, but will proceed with the installation/use if another file with a valid version can be found:
![bad-version-success](https://github.com/user-attachments/assets/65fbba8d-a114-4674-b753-b7d4250dfd9d)

.godotrc files with a leading tilde (~) character will cause non-.NET versions to be installed or used:
![godotrc-use-no-dotnet](https://github.com/user-attachments/assets/e03a784b-ce40-4ab3-9e1e-ba510dd5eefb)

A global.json (specifying v4.4.1) in the directory above the working directory will override a csproj in the working directory (specifying v4.4.0):
![parent-globaljson-overrides-csproj](https://github.com/user-attachments/assets/50c0295d-a2aa-4568-8cc2-5edf89a99f86)