### PR TITLE
feat: pin command for pinning Godot version in project

### DIFF
--- a/GodotEnv.Tests/reports/branch_coverage.svg
+++ b/GodotEnv.Tests/reports/branch_coverage.svg
@@ -124,7 +124,7 @@
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
         
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">56.7%</text><text class="" x="132.5" y="14">56.7%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">56.9%</text><text class="" x="132.5" y="14">56.9%</text>
         
         
     </g>

--- a/GodotEnv.Tests/reports/line_coverage.svg
+++ b/GodotEnv.Tests/reports/line_coverage.svg
@@ -123,7 +123,7 @@
 
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">62.7%</text><text class="" x="132.5" y="14">62.7%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">62.5%</text><text class="" x="132.5" y="14">62.5%</text>
         
         
         

--- a/GodotEnv.Tests/reports/method_coverage.svg
+++ b/GodotEnv.Tests/reports/method_coverage.svg
@@ -125,7 +125,7 @@
         <text x="53" y="14" fill="#fff">Coverage</text>
         
         
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">66.5%</text><text class="" x="132.5" y="14">66.5%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">66.6%</text><text class="" x="132.5" y="14">66.6%</text>
         
     </g>
 

--- a/GodotEnv.Tests/src/features/godot/domain/GodotVersionSpecifierRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/godot/domain/GodotVersionSpecifierRepositoryTest.cs
@@ -2,11 +2,15 @@ namespace Chickensoft.GodotEnv.Tests.Features.Config.Commands.List;
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.IO.Abstractions;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Chickensoft.GodotEnv.Common.Clients;
 using Chickensoft.GodotEnv.Common.Utilities;
 using Chickensoft.GodotEnv.Features.Godot.Domain;
 using Chickensoft.GodotEnv.Features.Godot.Models;
+using Chickensoft.GodotEnv.Features.Godot.Serializers;
 using Moq;
 using Shouldly;
 using Xunit;
@@ -173,6 +177,175 @@ public class GodotVersionSpecifierRepositoryTest {
     var repo = new GodotVersionSpecifierRepository("test/working-dir", fileClient.Object);
 
     repo.InferVersion(Enumerate(fileMocks, m => m.Object), log.Object).ShouldBe(null);
+  }
+
+  [Fact]
+  public void ProjectDirectoryIsHighestSolutionIfGodotProjectLower() {
+    var directoryNames = new List<string> {
+      "/test/path/to/project",
+      "/test/path/to",
+      "/test/path",
+      "/test",
+      "/",
+    };
+    var directoryMocks = new List<Mock<IDirectoryInfo>> {
+      new(),
+      new(),
+      new(),
+      new(),
+      new(),
+    };
+    for (var i = 0; i < directoryMocks.Count; ++i) {
+      directoryMocks[i].Setup(dir => dir.FullName).Returns(directoryNames[i]);
+      if (i < directoryMocks.Count - 1) {
+        directoryMocks[i].Setup(dir => dir.Parent).Returns(directoryMocks[i + 1].Object);
+      }
+    }
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(
+        client => client.GetAncestorDirectories(directoryNames[0])
+      ).Returns(Enumerate(directoryMocks, m => m.Object));
+    fileClient.Setup(
+      client => client.GetFiles(directoryNames[0], "*.sln")
+    ).Returns((string dir, string pattern) => [$"{dir}/Other.sln"]);
+    fileClient.Setup(
+      client => client.GetFiles(directoryNames[2], "*.sln")
+    ).Returns((string dir, string pattern) => [$"{dir}/Project.sln"]);
+    fileClient.Setup(
+      client => client.GetFiles(directoryNames[1], "project.godot")
+    ).Returns((string dir, string pattern) => [$"{dir}/project.godot"]);
+
+    var repo = new GodotVersionSpecifierRepository(directoryNames[0], fileClient.Object);
+    repo.GetProjectDefinitionDirectory().ShouldBe(directoryNames[2]);
+  }
+
+  [Fact]
+  public void ProjectDirectoryIsHighestSolutionIfGodotProjectHigher() {
+    var directoryNames = new List<string> {
+      "/test/path/to/project",
+      "/test/path/to",
+      "/test/path",
+      "/test",
+      "/",
+    };
+    var directoryMocks = new List<Mock<IDirectoryInfo>> {
+      new(),
+      new(),
+      new(),
+      new(),
+      new(),
+    };
+    for (var i = 0; i < directoryMocks.Count; ++i) {
+      directoryMocks[i].Setup(dir => dir.FullName).Returns(directoryNames[i]);
+      if (i < directoryMocks.Count - 1) {
+        directoryMocks[i].Setup(dir => dir.Parent).Returns(directoryMocks[i + 1].Object);
+      }
+    }
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(
+        client => client.GetAncestorDirectories(directoryNames[0])
+      ).Returns(Enumerate(directoryMocks, m => m.Object));
+    fileClient.Setup(
+      client => client.GetFiles(directoryNames[0], "*.sln")
+    ).Returns((string dir, string pattern) => [$"{dir}/Other.sln"]);
+    fileClient.Setup(
+      client => client.GetFiles(directoryNames[2], "*.sln")
+    ).Returns((string dir, string pattern) => [$"{dir}/Project.sln"]);
+    fileClient.Setup(
+      client => client.GetFiles(directoryNames[3], "project.godot")
+    ).Returns((string dir, string pattern) => [$"{dir}/project.godot"]);
+
+    var repo = new GodotVersionSpecifierRepository(directoryNames[0], fileClient.Object);
+    repo.GetProjectDefinitionDirectory().ShouldBe(directoryNames[2]);
+  }
+
+  [Fact]
+  public void ProjectDirectoryIsHighestGodotProjectIfNoSln() {
+    var directoryNames = new List<string> {
+      "/test/path/to/project",
+      "/test/path/to",
+      "/test/path",
+      "/test",
+      "/",
+    };
+    var directoryMocks = new List<Mock<IDirectoryInfo>> {
+      new(),
+      new(),
+      new(),
+      new(),
+      new(),
+    };
+    for (var i = 0; i < directoryMocks.Count; ++i) {
+      directoryMocks[i].Setup(dir => dir.FullName).Returns(directoryNames[i]);
+      if (i < directoryMocks.Count - 1) {
+        directoryMocks[i].Setup(dir => dir.Parent).Returns(directoryMocks[i + 1].Object);
+      }
+    }
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(
+        client => client.GetAncestorDirectories(directoryNames[0])
+      ).Returns(Enumerate(directoryMocks, m => m.Object));
+    fileClient.Setup(
+      client => client.GetFiles(directoryNames[2], "project.godot")
+    ).Returns((string dir, string pattern) => [$"{dir}/project.godot"]);
+    fileClient.Setup(
+      client => client.GetFiles(directoryNames[3], "project.godot")
+    ).Returns((string dir, string pattern) => [$"{dir}/project.godot"]);
+
+    var repo = new GodotVersionSpecifierRepository(directoryNames[0], fileClient.Object);
+    repo.GetProjectDefinitionDirectory().ShouldBe(directoryNames[3]);
+  }
+
+  [Fact]
+  public void PinVersionWritesGlobalJsonForDotnetVersion() {
+    var projectDir = "/test/path";
+    var expectedRawJson =
+      /*lang=json,strict*/
+      """
+      {
+        "msbuild-sdks": {
+          "Godot.NET.Sdk": "4.4.1"
+        }
+      }
+      """;
+    var expectedNode = JsonNode.Parse(expectedRawJson);
+    var serializerOptions = new JsonSerializerOptions() { WriteIndented = true };
+
+    var path = "/test/path/global.json";
+    var version = new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true);
+    var writer = new Mock<TextWriter>();
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.Combine(projectDir, "global.json")).Returns(path);
+    fileClient.Setup(client => client.FileExists(path)).Returns(false);
+    fileClient.Setup(client => client.GetWriter(path)).Returns(writer.Object);
+    var log = new Mock<ILog>();
+    var repo = new GodotVersionSpecifierRepository(projectDir, fileClient.Object);
+
+    repo.PinVersion(version, projectDir, log.Object);
+
+    writer.Verify(wrt => wrt.WriteLine(expectedNode!.ToJsonString(serializerOptions)));
+    log.Verify(log => log.Info($"Writing Godot version \"{new IoVersionSerializer().SerializeWithDotnetStatus(version)}\" to {path}"));
+  }
+
+  [Fact]
+  public void PinVersionWritesGodotrcForNonDotnetVersion() {
+    var projectDir = "/test/path";
+    var path = "/test/path/.godotrc";
+    var version = new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, false);
+    var serializer = new IoVersionSerializer();
+    var versionString = serializer.SerializeWithDotnetStatus(version);
+    var writer = new Mock<TextWriter>();
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.Combine(projectDir, ".godotrc")).Returns(path);
+    fileClient.Setup(client => client.FileExists(path)).Returns(false);
+    fileClient.Setup(client => client.GetWriter(path)).Returns(writer.Object);
+    var log = new Mock<ILog>();
+    var repo = new GodotVersionSpecifierRepository(projectDir, fileClient.Object);
+
+    repo.PinVersion(version, projectDir, log.Object);
+
+    writer.Verify(wrt => wrt.WriteLine(versionString));
+    log.Verify(log => log.Info($"Writing Godot version \"{versionString}\" to {path}"));
   }
 
   public IEnumerable<TResult> Enumerate<TResult, TCollection>(

--- a/GodotEnv.Tests/src/features/godot/models/CsprojFileTest.cs
+++ b/GodotEnv.Tests/src/features/godot/models/CsprojFileTest.cs
@@ -183,4 +183,13 @@ public class CsprojFileTest {
     fileClient.Setup(client => client.GetReader(path)).Returns(reader);
     Should.Throw<ArgumentException>(() => file.ParseGodotVersion(fileClient.Object));
   }
+
+  [Fact]
+  public void WriteGodotVersionThrowsNotSupported() {
+    var path = "/test/path";
+    var fileClient = new Mock<IFileClient>();
+    var file = new CsprojFile(path);
+    var version = new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true);
+    Should.Throw<NotSupportedException>(() => file.WriteGodotVersion(version, fileClient.Object));
+  }
 }

--- a/GodotEnv.Tests/src/features/godot/models/GlobalJsonFileTest.cs
+++ b/GodotEnv.Tests/src/features/godot/models/GlobalJsonFileTest.cs
@@ -2,6 +2,7 @@ namespace Chickensoft.GodotEnv.Tests.Features.Godot.Models;
 
 using System;
 using System.IO;
+using System.Text.Json.Nodes;
 using Chickensoft.GodotEnv.Common.Clients;
 using Chickensoft.GodotEnv.Features.Godot.Models;
 using Moq;
@@ -98,6 +99,125 @@ public class GlobalJsonFileTest {
       var fileClient = new Mock<IFileClient>();
       fileClient.Setup(client => client.GetReadStream(path)).Returns(stream);
       Should.Throw<ArgumentException>(() => file.ParseGodotVersion(fileClient.Object));
+    }
+  }
+
+  [Fact]
+  public void WriteGodotVersionOpensWriterToNewFileAndWritesVersionWithDotnetStatus() {
+    var expectedRawJson =
+      /*lang=json,strict*/
+      """
+      {
+        "msbuild-sdks": {
+          "Godot.NET.Sdk": "4.4.1"
+        }
+      }
+      """;
+    var expectedNode = JsonNode.Parse(expectedRawJson);
+
+    var path = "/test/path/global.json";
+    var version = new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true);
+    var file = new GlobalJsonFile(path);
+    var writer = new Mock<TextWriter>();
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.FileExists(path)).Returns(false);
+    fileClient.Setup(client => client.GetWriter(path)).Returns(writer.Object);
+    file.WriteGodotVersion(version, fileClient.Object);
+    writer.Verify(wrt => wrt.WriteLine(expectedNode!.ToJsonString(file.JsonSerializerOptions)));
+  }
+
+  [Fact]
+  public void WriteGodotVersionOpensWriterToExistingFileAndWritesNewMsbuildSdkSectionAndVersionWithDotnetStatus() {
+    var existingJson =
+      /*lang=json,strict*/
+      """
+      {
+        "sdk": {
+          "version": "8.0.410",
+          "rollForward": "latestMinor"
+        }
+      }
+      """;
+    var expectedRawJson =
+      /*lang=json,strict*/
+      """
+      {
+        "sdk": {
+          "version": "8.0.410",
+          "rollForward": "latestMinor"
+        },
+        "msbuild-sdks": {
+          "Godot.NET.Sdk": "4.4.1"
+        }
+      }
+      """;
+    var expectedNode = JsonNode.Parse(expectedRawJson);
+
+    var path = "/test/path/global.json";
+    var version = new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true);
+    var file = new GlobalJsonFile(path);
+    using (var stream = new MemoryStream()) {
+      using (var existingWriter = new StreamWriter(stream, leaveOpen: true)) {
+        existingWriter.Write(existingJson);
+        existingWriter.Flush();
+      }
+      stream.Position = 0;
+      var writer = new Mock<TextWriter>();
+      var fileClient = new Mock<IFileClient>();
+      fileClient.Setup(client => client.FileExists(path)).Returns(true);
+      fileClient.Setup(client => client.GetReadStream(path)).Returns(stream);
+      fileClient.Setup(client => client.GetWriter(path)).Returns(writer.Object);
+      file.WriteGodotVersion(version, fileClient.Object);
+      writer.Verify(wrt => wrt.WriteLine(expectedNode!.ToJsonString(file.JsonSerializerOptions)));
+    }
+  }
+
+  [Fact]
+  public void WriteGodotVersionOpensWriterToExistingFileAndOverwritesExistingVersionWithDotnetStatus() {
+    var existingJson =
+      /*lang=json,strict*/
+      """
+      {
+        "sdk": {
+          "version": "8.0.410",
+          "rollForward": "latestMinor"
+        },
+        "msbuild-sdks": {
+          "Godot.NET.Sdk": "4.3.0"
+        }
+      }
+      """;
+    var expectedRawJson =
+      /*lang=json,strict*/
+      """
+      {
+        "sdk": {
+          "version": "8.0.410",
+          "rollForward": "latestMinor"
+        },
+        "msbuild-sdks": {
+          "Godot.NET.Sdk": "4.4.1"
+        }
+      }
+      """;
+    var expectedNode = JsonNode.Parse(expectedRawJson);
+
+    var path = "/test/path/global.json";
+    var version = new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true);
+    var file = new GlobalJsonFile(path);
+    using (var stream = new MemoryStream()) {
+      using (var existingWriter = new StreamWriter(stream, leaveOpen: true)) {
+        existingWriter.Write(existingJson);
+        existingWriter.Flush();
+      }
+      stream.Position = 0;
+      var writer = new Mock<TextWriter>();
+      var fileClient = new Mock<IFileClient>();
+      fileClient.Setup(client => client.FileExists(path)).Returns(true);
+      fileClient.Setup(client => client.GetReadStream(path)).Returns(stream);
+      fileClient.Setup(client => client.GetWriter(path)).Returns(writer.Object);
+      file.WriteGodotVersion(version, fileClient.Object);
+      writer.Verify(wrt => wrt.WriteLine(expectedNode!.ToJsonString(file.JsonSerializerOptions)));
     }
   }
 }

--- a/GodotEnv.Tests/src/features/godot/models/GodotRcFileTest.cs
+++ b/GodotEnv.Tests/src/features/godot/models/GodotRcFileTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using Chickensoft.GodotEnv.Common.Clients;
 using Chickensoft.GodotEnv.Features.Godot.Models;
+using Chickensoft.GodotEnv.Features.Godot.Serializers;
 using Moq;
 using Shouldly;
 using Xunit;
@@ -88,5 +89,18 @@ public class GodotRcFileTest {
     var fileClient = new Mock<IFileClient>();
     fileClient.Setup(client => client.GetReader(path)).Returns(reader.Object);
     Should.Throw<ArgumentException>(() => file.ParseGodotVersion(fileClient.Object));
+  }
+
+  [Fact]
+  public void WriteGodotVersionOpensWriterToFileAndWritesVersionWithDotnetStatus() {
+    var path = "/test/path/.godotrc";
+    var version = new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true);
+    var serializer = new IoVersionSerializer();
+    var file = new GodotrcFile(path);
+    var writer = new Mock<TextWriter>();
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.GetWriter(path)).Returns(writer.Object);
+    file.WriteGodotVersion(version, fileClient.Object);
+    writer.Verify(wrt => wrt.WriteLine(serializer.SerializeWithDotnetStatus(version)));
   }
 }

--- a/GodotEnv.Tests/src/features/godot/models/GodotRcFileTest.cs
+++ b/GodotEnv.Tests/src/features/godot/models/GodotRcFileTest.cs
@@ -92,9 +92,22 @@ public class GodotRcFileTest {
   }
 
   [Fact]
-  public void WriteGodotVersionOpensWriterToFileAndWritesVersionWithDotnetStatus() {
+  public void WriteGodotVersionOpensWriterToFileAndWritesVersionWithoutDotnetStatusIfDotnet() {
     var path = "/test/path/.godotrc";
     var version = new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true);
+    var serializer = new IoVersionSerializer();
+    var file = new GodotrcFile(path);
+    var writer = new Mock<TextWriter>();
+    var fileClient = new Mock<IFileClient>();
+    fileClient.Setup(client => client.GetWriter(path)).Returns(writer.Object);
+    file.WriteGodotVersion(version, fileClient.Object);
+    writer.Verify(wrt => wrt.WriteLine(serializer.Serialize(version)));
+  }
+
+  [Fact]
+  public void WriteGodotVersionOpensWriterToFileAndWritesVersionWithDotnetStatusIfNotDotnet() {
+    var path = "/test/path/.godotrc";
+    var version = new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, false);
     var serializer = new IoVersionSerializer();
     var file = new GodotrcFile(path);
     var writer = new Mock<TextWriter>();

--- a/GodotEnv.Tests/src/features/godot/serializers/IoVersionSerializerTest.cs
+++ b/GodotEnv.Tests/src/features/godot/serializers/IoVersionSerializerTest.cs
@@ -3,6 +3,7 @@ namespace Chickensoft.GodotEnv.Tests.Features.Godot.Models;
 using System.Collections.Generic;
 using Chickensoft.GodotEnv.Features.Godot.Models;
 using Chickensoft.GodotEnv.Features.Godot.Serializers;
+using Shouldly;
 using Xunit;
 
 public class IoVersionStringConverterTest {
@@ -21,5 +22,19 @@ public class IoVersionStringConverterTest {
     Assert.Equal(expected, serializer.Serialize(new AnyDotnetStatusGodotVersion(toFormat)));
     Assert.Equal(expected, serializer.Serialize(new SpecificDotnetStatusGodotVersion(toFormat, true)));
     Assert.Equal(expected, serializer.Serialize(new SpecificDotnetStatusGodotVersion(toFormat, false)));
+  }
+
+  [Fact]
+  public void CorrectDotnetStatusSerialization() {
+    var serializer = new IoVersionSerializer();
+    serializer.SerializeWithDotnetStatus(new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true))
+      .ShouldBe("4.4.1-stable dotnet");
+  }
+
+  [Fact]
+  public void CorrectNoDotnetStatusSerialization() {
+    var serializer = new IoVersionSerializer();
+    serializer.SerializeWithDotnetStatus(new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, false))
+      .ShouldBe("4.4.1-stable no-dotnet");
   }
 }

--- a/GodotEnv.Tests/src/features/godot/serializers/OldDiskVersionSerializerTest.cs
+++ b/GodotEnv.Tests/src/features/godot/serializers/OldDiskVersionSerializerTest.cs
@@ -3,6 +3,7 @@ namespace Chickensoft.GodotEnv.Tests.Features.Godot.Models;
 using System.Collections.Generic;
 using Chickensoft.GodotEnv.Features.Godot.Models;
 using Chickensoft.GodotEnv.Features.Godot.Serializers;
+using Shouldly;
 using Xunit;
 
 public class OldDiskVersionSerializerTest {
@@ -61,5 +62,19 @@ public class OldDiskVersionSerializerTest {
     Assert.Equal(expected, serializer.Serialize(new AnyDotnetStatusGodotVersion(toFormat)));
     Assert.Equal(expected, serializer.Serialize(new SpecificDotnetStatusGodotVersion(toFormat, true)));
     Assert.Equal(expected, serializer.Serialize(new SpecificDotnetStatusGodotVersion(toFormat, false)));
+  }
+
+  [Fact]
+  public void CorrectDotnetStatusSerialization() {
+    var serializer = new OldDiskVersionSerializer();
+    serializer.SerializeWithDotnetStatus(new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true))
+      .ShouldBe("4.4.1 dotnet");
+  }
+
+  [Fact]
+  public void CorrectNoDotnetStatusSerialization() {
+    var serializer = new OldDiskVersionSerializer();
+    serializer.SerializeWithDotnetStatus(new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, false))
+      .ShouldBe("4.4.1 no-dotnet");
   }
 }

--- a/GodotEnv.Tests/src/features/godot/serializers/ReleaseVersionSerializerTest.cs
+++ b/GodotEnv.Tests/src/features/godot/serializers/ReleaseVersionSerializerTest.cs
@@ -3,6 +3,7 @@ namespace Chickensoft.GodotEnv.Tests.Features.Godot.Models;
 using System.Collections.Generic;
 using Chickensoft.GodotEnv.Features.Godot.Models;
 using Chickensoft.GodotEnv.Features.Godot.Serializers;
+using Shouldly;
 using Xunit;
 
 public class ReleaseVersionSerializerTest {
@@ -22,5 +23,19 @@ public class ReleaseVersionSerializerTest {
     Assert.Equal(expected, serializer.Serialize(new AnyDotnetStatusGodotVersion(toFormat)));
     Assert.Equal(expected, serializer.Serialize(new SpecificDotnetStatusGodotVersion(toFormat, true)));
     Assert.Equal(expected, serializer.Serialize(new SpecificDotnetStatusGodotVersion(toFormat, false)));
+  }
+
+  [Fact]
+  public void CorrectDotnetStatusSerialization() {
+    var serializer = new ReleaseVersionSerializer();
+    serializer.SerializeWithDotnetStatus(new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true))
+      .ShouldBe("4.4.1-stable dotnet");
+  }
+
+  [Fact]
+  public void CorrectNoDotnetStatusSerialization() {
+    var serializer = new ReleaseVersionSerializer();
+    serializer.SerializeWithDotnetStatus(new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, false))
+      .ShouldBe("4.4.1-stable no-dotnet");
   }
 }

--- a/GodotEnv.Tests/src/features/godot/serializers/SharpVersionSerializerTest.cs
+++ b/GodotEnv.Tests/src/features/godot/serializers/SharpVersionSerializerTest.cs
@@ -3,6 +3,7 @@ namespace Chickensoft.GodotEnv.Tests.Features.Godot.Models;
 using System.Collections.Generic;
 using Chickensoft.GodotEnv.Features.Godot.Models;
 using Chickensoft.GodotEnv.Features.Godot.Serializers;
+using Shouldly;
 using Xunit;
 
 public class SharpVersionSerializerTest {
@@ -21,5 +22,19 @@ public class SharpVersionSerializerTest {
     Assert.Equal(expected, converter.Serialize(new AnyDotnetStatusGodotVersion(toFormat)));
     Assert.Equal(expected, converter.Serialize(new SpecificDotnetStatusGodotVersion(toFormat, true)));
     Assert.Equal(expected, converter.Serialize(new SpecificDotnetStatusGodotVersion(toFormat, false)));
+  }
+
+  [Fact]
+  public void CorrectDotnetStatusSerialization() {
+    var serializer = new SharpVersionSerializer();
+    serializer.SerializeWithDotnetStatus(new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, true))
+      .ShouldBe("4.4.1 dotnet");
+  }
+
+  [Fact]
+  public void CorrectNoDotnetStatusSerialization() {
+    var serializer = new SharpVersionSerializer();
+    serializer.SerializeWithDotnetStatus(new SpecificDotnetStatusGodotVersion(4, 4, 1, "stable", -1, false))
+      .ShouldBe("4.4.1 no-dotnet");
   }
 }

--- a/GodotEnv/src/common/clients/FileClient.cs
+++ b/GodotEnv/src/common/clients/FileClient.cs
@@ -231,6 +231,20 @@ public interface IFileClient {
   public TextReader GetReader(string path);
 
   /// <summary>
+  /// Get a <see cref="TextWriter"/> for a given file path.
+  /// </summary>
+  /// <param name="path">File to write.</param>
+  /// <returns>
+  /// A writer to use for writing to the file. This value must be disposed by
+  /// the caller.
+  /// </returns>
+  /// <remarks>
+  /// Clears the file contents; if you wish to modify or append to them, you
+  /// must read them in before calling this method.
+  /// </remarks>
+  public TextWriter GetWriter(string path);
+
+  /// <summary>
   /// Get a <see cref="Stream"/> for reading a given file.
   /// </summary>
   /// <param name="path">File to read.</param>
@@ -553,12 +567,7 @@ public class FileClient : IFileClient {
   public IEnumerable<IDirectoryInfo> GetSubdirectories(string dir) =>
     Files.DirectoryInfo.New(dir).EnumerateDirectories();
 
-  /// <summary>
-  /// Gets an enumerable over the given directory and its ancestor directories,
-  /// starting with itself and finishing with the root directory.
-  /// </summary>
-  /// <param name="dir">The directory to start from.</param>
-  /// <returns>An enumerable over the directory and its ancestors.</returns>
+  /// <inheritdoc/>
   public IEnumerable<IDirectoryInfo> GetAncestorDirectories(string dir) {
     var directoryInfo = Files.DirectoryInfo.New(dir);
     while (directoryInfo is not null) {
@@ -617,8 +626,13 @@ public class FileClient : IFileClient {
     Files.File.WriteAllText(filePath, contents);
   }
 
+  /// <inheritdoc/>
   public TextReader GetReader(string path) => new StreamReader(path);
 
+  /// <inheritdoc/>
+  public TextWriter GetWriter(string path) => new StreamWriter(path);
+
+  /// <inheritdoc/>
   public Stream GetReadStream(string path) => File.OpenRead(path);
 
   public List<string> ReadLines(string path) =>

--- a/GodotEnv/src/features/godot/commands/GodotPinCommand.cs
+++ b/GodotEnv/src/features/godot/commands/GodotPinCommand.cs
@@ -1,0 +1,81 @@
+namespace Chickensoft.GodotEnv.Features.Addons.Commands;
+
+using System;
+using System.Threading.Tasks;
+using Chickensoft.GodotEnv.Common.Models;
+using Chickensoft.GodotEnv.Features.Godot.Models;
+using CliFx;
+using CliFx.Attributes;
+using CliFx.Infrastructure;
+
+[Command(
+  "godot pin",
+  Description = "Pins the current Godot project to the active Godot version by "
+    + "writing a version-specifier file to the project directory."
+)]
+public class GodotPinCommand : ICommand, ICliCommand, IWindowsElevationEnabled {
+  public IExecutionContext ExecutionContext { get; set; } = default!;
+
+  public bool IsWindowsElevationRequired => false;
+
+  public GodotPinCommand(IExecutionContext context) {
+    ExecutionContext = context;
+  }
+
+  public async ValueTask ExecuteAsync(IConsole console) {
+    var godotRepo = ExecutionContext.Godot.GodotRepo;
+    var platform = ExecutionContext.Godot.Platform;
+
+    var log = ExecutionContext.CreateLog(console);
+    var output = console.Output;
+
+    SpecificDotnetStatusGodotVersion? version = null;
+
+    foreach (var result in godotRepo.GetInstallationsList()) {
+      if (
+        result.Value is GodotInstallation installation
+          && installation.IsActiveVersion
+      ) {
+        version = installation.Version;
+      }
+    }
+
+    if (version is null) {
+      log.Err("No active Godot version found.");
+      log.Print("To install a Godot version, run:");
+      log.Print("");
+      log.Success("    godotenv godot install <version>");
+      log.Print("");
+      log.Print("To activate an installed version, run:");
+      log.Print("");
+      log.Success("    godotenv godot use <version>");
+      return;
+    }
+
+    var versionRepo = ExecutionContext.Godot.VersionRepo;
+
+    var projectDir = versionRepo.GetProjectDefinitionDirectory();
+    if (string.IsNullOrEmpty(projectDir)) {
+      log.Err("No Godot project found in this or any ancestor directory.");
+      log.Print("Please run this command in a directory or subdirectory of");
+      log.Print("a Godot project containing either a .sln file or");
+      log.Print("a project.godot file.");
+      return;
+    }
+
+    try {
+      versionRepo.PinVersion(version, projectDir, log);
+    }
+    catch (Exception e) {
+      log.Err("An error occurred while pinning the current Godot version:");
+      log.Print(e.Message);
+    }
+
+    await Task.CompletedTask;
+
+    log.Print("");
+    log.Success(
+      $"Godot version `{godotRepo.VersionSerializer.SerializeWithDotnetStatus(version)}` is now pinned as the preferred project version."
+    );
+  }
+}

--- a/GodotEnv/src/features/godot/domain/GodotRepository.cs
+++ b/GodotEnv/src/features/godot/domain/GodotRepository.cs
@@ -247,8 +247,7 @@ public partial class GodotRepository : IGodotRepository {
   ) => ReadInstallation(version);
 
   public string InstallationVersionName(GodotInstallation installation) =>
-    VersionSerializer.Serialize(installation.Version) +
-      (installation.Version.IsDotnetEnabled ? " dotnet" : " no-dotnet");
+    VersionSerializer.SerializeWithDotnetStatus(installation.Version);
 
   public void ClearCache() {
     if (FileClient.DirectoryExists(GodotCachePath)) {

--- a/GodotEnv/src/features/godot/domain/GodotVersionSpecifierRepository.cs
+++ b/GodotEnv/src/features/godot/domain/GodotVersionSpecifierRepository.cs
@@ -2,13 +2,19 @@ namespace Chickensoft.GodotEnv.Features.Godot.Domain;
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Chickensoft.GodotEnv.Common.Clients;
 using Chickensoft.GodotEnv.Common.Utilities;
 using Chickensoft.GodotEnv.Features.Godot.Models;
+using Chickensoft.GodotEnv.Features.Godot.Serializers;
 
 public interface IGodotVersionSpecifierRepository {
   public string WorkingDir { get; set; }
   public IFileClient FileClient { get; set; }
+  /// <summary>
+  /// Version serializer used for log messages (not version-specifier files).
+  /// </summary>
+  public IVersionSerializer VersionSerializer { get; set; }
 
   public SpecificDotnetStatusGodotVersion? InferVersion(
     IEnumerable<IGodotVersionFile> godotVersionFiles,
@@ -19,11 +25,48 @@ public interface IGodotVersionSpecifierRepository {
     ILog log
   );
   public IEnumerable<IGodotVersionFile> GetVersionFiles();
+
+  /// <summary>
+  /// Find the highest directory from the working directory that contains a
+  /// ".sln" file (if one exists), or the highest directory from the working
+  /// directory that contains a "project.godot" file (if no ".sln" file exists).
+  /// </summary>
+  /// <returns>
+  /// The full path to the highest directory up the directory tree containing a
+  /// ".sln" file, or the full path to the highest directory up the directory
+  /// tree containing a "project.godot" file if no directory in the hierarchy
+  /// contains a ".sln" file, or the empty string if no directory in the
+  /// hierarchy contains a ".sln" or "project.godot" file.
+  /// </returns>
+  public string GetProjectDefinitionDirectory();
+
+  /// <summary>
+  /// Write a version-specifier file into the given project directory,
+  /// indicating the provided Godot version as the preferred version for the
+  /// project.
+  ///
+  /// The file used will be global.json for a .NET Godot version, or .godotrc
+  /// for a non-.NET Godot version.
+  /// </summary>
+  /// <param name="version">
+  /// The Godot version to write to a version-specifying file.
+  /// </param>
+  /// <param name="projectDir">
+  /// The project directory in which to write a version-specifying file.
+  /// </param>
+  /// <param name="log">Log object for messaging.</param>
+  public void PinVersion(
+    SpecificDotnetStatusGodotVersion version,
+    string projectDir,
+    ILog log
+  );
 }
 
 public class GodotVersionSpecifierRepository : IGodotVersionSpecifierRepository {
   public string WorkingDir { get; set; }
   public IFileClient FileClient { get; set; }
+  /// <inheritdoc/>
+  public IVersionSerializer VersionSerializer { get; set; }
 
   public GodotVersionSpecifierRepository(
     string workingDir,
@@ -31,6 +74,7 @@ public class GodotVersionSpecifierRepository : IGodotVersionSpecifierRepository 
   ) {
     WorkingDir = workingDir;
     FileClient = fileClient;
+    VersionSerializer = new IoVersionSerializer();
   }
 
   public SpecificDotnetStatusGodotVersion? InferVersion(
@@ -40,6 +84,7 @@ public class GodotVersionSpecifierRepository : IGodotVersionSpecifierRepository 
     foreach (var godotVersionFile in godotVersionFiles) {
       var version = GetValidatedGodotVersion(godotVersionFile, log);
       if (version is not null) {
+        log.Info($"Retrieved version from {godotVersionFile.FilePath}.");
         return version;
       }
     }
@@ -64,9 +109,7 @@ public class GodotVersionSpecifierRepository : IGodotVersionSpecifierRepository 
     List<GlobalJsonFile> globalJsonFiles = [];
     List<CsprojFile> csprojFiles = [];
     List<GodotrcFile> godotrcFiles = [];
-    foreach (var directory
-      in FileClient.GetAncestorDirectories(WorkingDir)
-    ) {
+    foreach (var directory in FileClient.GetAncestorDirectories(WorkingDir)) {
       var globalJsonPath = FileClient.Combine(directory.FullName, "global.json");
       if (FileClient.FileExists(globalJsonPath)) {
         globalJsonFiles.Add(new GlobalJsonFile(globalJsonPath));
@@ -86,5 +129,36 @@ public class GodotVersionSpecifierRepository : IGodotVersionSpecifierRepository 
     files.AddRange(csprojFiles);
     files.AddRange(godotrcFiles);
     return files;
+  }
+
+  /// <inheritdoc/>
+  public string GetProjectDefinitionDirectory() {
+    var slnDir = string.Empty;
+    var godotProjectDir = string.Empty;
+    foreach (var directory in FileClient.GetAncestorDirectories(WorkingDir)) {
+      if (FileClient.GetFiles(directory.FullName, "*.sln").Any()) {
+        slnDir = directory.FullName;
+      }
+      if (FileClient.GetFiles(directory.FullName, "project.godot").Any()) {
+        godotProjectDir = directory.FullName;
+      }
+    }
+    if (!string.IsNullOrEmpty(slnDir)) {
+      return slnDir;
+    }
+    return godotProjectDir;
+  }
+
+  /// <inheritdoc/>
+  public void PinVersion(
+    SpecificDotnetStatusGodotVersion version,
+    string projectDir,
+    ILog log
+  ) {
+    IGodotVersionFile file = version.IsDotnetEnabled
+      ? new GlobalJsonFile(FileClient.Combine(projectDir, "global.json"))
+      : new GodotrcFile(FileClient.Combine(projectDir, ".godotrc"));
+    log.Info($"Writing Godot version \"{VersionSerializer.SerializeWithDotnetStatus(version)}\" to {file.FilePath}");
+    file.WriteGodotVersion(version, FileClient);
   }
 }

--- a/GodotEnv/src/features/godot/models/CsprojFile.cs
+++ b/GodotEnv/src/features/godot/models/CsprojFile.cs
@@ -45,6 +45,13 @@ public class CsprojFile : IGodotVersionFile, IEquatable<CsprojFile> {
     return _versionDeserializer.Deserialize(version, true);
   }
 
+  /// <inheritdoc/>
+  public void WriteGodotVersion(
+    SpecificDotnetStatusGodotVersion version,
+    IFileClient fileClient
+  ) =>
+    throw new NotSupportedException("Writing Godot version information to csproj files is not supported.");
+
   public bool Equals(CsprojFile? other) =>
     other is not null && FilePath == other.FilePath;
 

--- a/GodotEnv/src/features/godot/models/GodotrcFile.cs
+++ b/GodotEnv/src/features/godot/models/GodotrcFile.cs
@@ -11,6 +11,7 @@ public class GodotrcFile : IGodotVersionFile, IEquatable<GodotrcFile> {
     " not-dotnet",
   ];
   private static readonly IoVersionDeserializer _versionDeserializer = new();
+  private static readonly IoVersionSerializer _versionSerializer = new();
 
   /// <inheritdoc/>
   public string FilePath { get; }
@@ -44,6 +45,19 @@ public class GodotrcFile : IGodotVersionFile, IEquatable<GodotrcFile> {
       }
     }
     return _versionDeserializer.Deserialize(version, isDotnet);
+  }
+
+  /// <inheritdoc/>
+  public void WriteGodotVersion(
+    SpecificDotnetStatusGodotVersion version,
+    IFileClient fileClient
+  ) {
+    // we can simply overwrite any existing .godotrc file
+    using (var writer = fileClient.GetWriter(FilePath)) {
+      writer.WriteLine(
+        _versionSerializer.SerializeWithDotnetStatus(version)
+      );
+    }
   }
 
   public bool Equals(GodotrcFile? other) =>

--- a/GodotEnv/src/features/godot/models/GodotrcFile.cs
+++ b/GodotEnv/src/features/godot/models/GodotrcFile.cs
@@ -55,7 +55,9 @@ public class GodotrcFile : IGodotVersionFile, IEquatable<GodotrcFile> {
     // we can simply overwrite any existing .godotrc file
     using (var writer = fileClient.GetWriter(FilePath)) {
       writer.WriteLine(
-        _versionSerializer.SerializeWithDotnetStatus(version)
+        version.IsDotnetEnabled
+          ? _versionSerializer.Serialize(version)
+          : _versionSerializer.SerializeWithDotnetStatus(version)
       );
     }
   }

--- a/GodotEnv/src/features/godot/models/IGodotVersionFile.cs
+++ b/GodotEnv/src/features/godot/models/IGodotVersionFile.cs
@@ -28,4 +28,20 @@ public interface IGodotVersionFile {
   public SpecificDotnetStatusGodotVersion? ParseGodotVersion(
     IFileClient fileClient
   );
+
+  /// <summary>
+  /// Writes a given Godot version into this file, if supported. Will overwrite
+  /// any existing Godot version information in the file.
+  /// </summary>
+  /// <param name="version">The version to write into the file.</param>
+  /// <param name="fileClient">
+  /// The file client to use for writing the file.
+  /// </param>
+  /// <exception cref="NotSupportedException">
+  /// If this file type does not support writing Godot versions.
+  /// </exception>
+  public void WriteGodotVersion(
+    SpecificDotnetStatusGodotVersion version,
+    IFileClient fileClient
+  );
 }

--- a/GodotEnv/src/features/godot/serializers/IVersionSerializer.cs
+++ b/GodotEnv/src/features/godot/serializers/IVersionSerializer.cs
@@ -3,5 +3,21 @@ namespace Chickensoft.GodotEnv.Features.Godot.Serializers;
 using Chickensoft.GodotEnv.Features.Godot.Models;
 
 public interface IVersionSerializer {
+  /// <summary>
+  /// Serialize the provided version to a version string.
+  /// </summary>
+  /// <param name="version">The version to serialize.</param>
+  /// <returns>A version string.</returns>
+  /// <remarks>The returned string does not include .NET status.</remarks>
+  /// <seealso cref="SerializeWithDotnetStatus"/>
   public string Serialize(GodotVersion version);
+
+  /// <summary>
+  /// Serialize the provided version to a version string with .NET status.
+  /// </summary>
+  /// <param name="version">The version to serialize.</param>
+  /// <returns>A version string including .NET status.</returns>
+  public string SerializeWithDotnetStatus(
+    SpecificDotnetStatusGodotVersion version
+  );
 }

--- a/GodotEnv/src/features/godot/serializers/IoVersionSerializer.cs
+++ b/GodotEnv/src/features/godot/serializers/IoVersionSerializer.cs
@@ -2,9 +2,9 @@ namespace Chickensoft.GodotEnv.Features.Godot.Serializers;
 
 using Chickensoft.GodotEnv.Features.Godot.Models;
 
-public partial class IoVersionSerializer : IVersionSerializer {
+public partial class IoVersionSerializer : VersionSerializer {
   private readonly ReleaseVersionSerializer _releaseConverter = new();
 
-  public string Serialize(GodotVersion version)
+  public override string Serialize(GodotVersion version)
     => _releaseConverter.Serialize(version);
 }

--- a/GodotEnv/src/features/godot/serializers/OldDiskVersionSerializer.cs
+++ b/GodotEnv/src/features/godot/serializers/OldDiskVersionSerializer.cs
@@ -6,7 +6,7 @@ using Chickensoft.GodotEnv.Features.Godot.Models;
 /// An <see cref="IVersionSerializer"> for Godot installations created by
 /// pre-2.11 versions of GodotEnv.
 /// </summary>
-public partial class OldDiskVersionSerializer : IVersionSerializer {
+public partial class OldDiskVersionSerializer : VersionSerializer {
   public bool OutputLabelSeparator { get; set; }
   public bool OutputPatchNumber { get; set; }
   public bool OutputStableLabel { get; set; }
@@ -21,7 +21,7 @@ public partial class OldDiskVersionSerializer : IVersionSerializer {
     OutputStableLabel = outputStableLabel;
   }
 
-  public string Serialize(GodotVersion version) {
+  public override string Serialize(GodotVersion version) {
     var result = $"{version.Number.Major}.{version.Number.Minor}";
     if (OutputPatchNumber || version.Number.Patch != 0) {
       result += $".{version.Number.Patch}";

--- a/GodotEnv/src/features/godot/serializers/ReleaseVersionSerializer.cs
+++ b/GodotEnv/src/features/godot/serializers/ReleaseVersionSerializer.cs
@@ -2,8 +2,8 @@ namespace Chickensoft.GodotEnv.Features.Godot.Serializers;
 
 using Chickensoft.GodotEnv.Features.Godot.Models;
 
-public partial class ReleaseVersionSerializer : IVersionSerializer {
-  public string Serialize(GodotVersion version) {
+public partial class ReleaseVersionSerializer : VersionSerializer {
+  public override string Serialize(GodotVersion version) {
     var result = $"{version.Number.Major}.{version.Number.Minor}";
     if (version.Number.Patch != 0) {
       result += $".{version.Number.Patch}";

--- a/GodotEnv/src/features/godot/serializers/SharpVersionSerializer.cs
+++ b/GodotEnv/src/features/godot/serializers/SharpVersionSerializer.cs
@@ -2,8 +2,8 @@ namespace Chickensoft.GodotEnv.Features.Godot.Serializers;
 
 using Chickensoft.GodotEnv.Features.Godot.Models;
 
-public partial class SharpVersionSerializer : IVersionSerializer {
-  public string Serialize(GodotVersion version) {
+public partial class SharpVersionSerializer : VersionSerializer {
+  public override string Serialize(GodotVersion version) {
     var versionString = string.Join(
       ".", version.Number.Major, version.Number.Minor, version.Number.Patch
     );

--- a/GodotEnv/src/features/godot/serializers/VersionSerializer.cs
+++ b/GodotEnv/src/features/godot/serializers/VersionSerializer.cs
@@ -1,0 +1,15 @@
+namespace Chickensoft.GodotEnv.Features.Godot.Serializers;
+
+using Chickensoft.GodotEnv.Features.Godot.Models;
+
+public abstract class VersionSerializer : IVersionSerializer {
+  /// <inheritdoc/>
+  public abstract string Serialize(GodotVersion version);
+
+  /// <inheritdoc/>
+  public virtual string SerializeWithDotnetStatus(
+    SpecificDotnetStatusGodotVersion version
+  ) =>
+    Serialize(version)
+      + (version.IsDotnetEnabled ? " dotnet" : " no-dotnet");
+}

--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ A `global.json` file at any directory level above the working directory will tak
 
 Versions from `global.json` or a `csproj` file are assumed to be .NET-enabled. A `.godotrc` file may specify a non-.NET Godot by appending a space and the string `no-dotnet` to the version string. For instance, a `.godotrc` file containing the value `4.0.1 no-dotnet` indicates the non-.NET version of Godot 4.0.1.
 
+### ✍️ Pinning the Current Godot Version for a Project
+
+To enable the version-free `godotenv godot install` and `godotenv godot use` commands without hand-authoring a version-specifying file for your project, you can use the `godotenv godot pin` command. This command will locate the top-level directory of your project and place a version-specifying file in it, indicating your active Godot version as the preferred version for the project.
+
+- To find the top-level directory of your project, the command walks up the directory tree from the working directory.
+  - If your project contains any `sln` files, the command will use the topmost directory containing a `sln` file.
+  - If your project does not contain any `sln` files, the command will use the topmost directory containing a `project.godot` file.
+- If your active Godot version is .NET-enabled, the command will add its version number as a `Godot.NET.Sdk` value in an existing `global.json` in the top-level project directory, or create a new `global.json` with the value if one does not exist.
+- If your active Godot version is not .NET-enabled, the command will place its version number in a `.godotrc` file in the top-level project directory, overwriting any existing `.godotrc` file in that location.
+
+Once the version-specifying file is created or updated with the preferred Godot version, you can commit it to source control for use by others on your team.
+
 ### 🚫 Uninstalling a Godot Version
 
 Uninstalling works the same way as installing and switching versions does.


### PR DESCRIPTION
Adds a `godotenv godot pin` command which pins the currently active Godot version as the preferred version for the project where the command is executed. This command creates a version-specifying file in the top-level project directory. This file can be used later by the version-free `godot install` and `godot use` commands to use the pinned Godot version.

To find the top-level project directory, the command walks up the directory tree from the working directory and selects the highest directory containing a `.sln` file, if one exists, or the highest directory containing a `project.godot` file if no `.sln` file exists in the directory tree.

If the currently active Godot version is .NET-enabled, the command writes the version as a Godot.NET.Sdk value in a `global.json` file in the top-level project directory. (If such a file exists, the value is written into it; if not, a new file is created.)
    
If the currently active Godot version is non-.NET, the command writes the version into a `.godotrc` file in the top-level project directory. The contents of any existing file are erased.

Screenshot of the pin command modifying an existing `global.json` in the same directory as the topmost `sln` file:
![modifies-globaljson](https://github.com/user-attachments/assets/f211a9cc-9586-48bd-8e66-1f3334cd5f00)

Screenshot of the pin command writing to a `.godotrc` in the same directory as the `project.godot` file when the active version is non-.NET and there is no `sln` file:
![project-godot-if-no-sln](https://github.com/user-attachments/assets/9ec11a0c-b1c3-4144-9abb-498003d6d671)
