### PR TITLE
fix: allow trailing commas in json via FileClient

### DIFF
--- a/GodotEnv.Tests/reports/line_coverage.svg
+++ b/GodotEnv.Tests/reports/line_coverage.svg
@@ -123,7 +123,7 @@
 
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">62.6%</text><text class="" x="132.5" y="14">62.6%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">62.7%</text><text class="" x="132.5" y="14">62.7%</text>
         
         
         

--- a/GodotEnv.Tests/src/common/clients/FileClientTest.cs
+++ b/GodotEnv.Tests/src/common/clients/FileClientTest.cs
@@ -2,6 +2,7 @@ namespace Chickensoft.GodotEnv.Tests;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
@@ -27,17 +28,29 @@ public class FileClientTest {
     }
   }
 
-  public const string JSON_FILE_CONTENTS = /*lang=json,strict*/ """
-                                                                {
-                                                                  "name": "test"
-                                                                }
-                                                                """;
+  public const string JSON_FILE_CONTENTS =
+    /*lang=json,strict*/
+    """
+    {
+      "name": "test"
+    }
+    """;
 
-  public const string JSON_FILE_CONTENTS_ALT = /*lang=json,strict*/ """
-                                                                    {
-                                                                      "name": "alternative"
-                                                                    }
-                                                                    """;
+  public const string JSON_FILE_CONTENTS_TRAILING_COMMA =
+    /*lang=json*/
+    """
+    {
+      "name": "test",
+    }
+    """;
+
+  public const string JSON_FILE_CONTENTS_ALT =
+    /*lang=json,strict*/
+    """
+    {
+      "name": "alternative"
+    }
+    """;
 
   [Theory]
   [MemberData(nameof(GetSystemInfoForUnixOSes))]
@@ -460,6 +473,22 @@ public class FileClientTest {
     var systemInfo = new MockSystemInfo(OSType.Linux, CPUArch.X64);
     var fs = new MockFileSystem(new Dictionary<string, MockFileData> {
       { "model.json", new MockFileData(JSON_FILE_CONTENTS) }
+    });
+
+    var computer = new Mock<IComputer>();
+    var client = new FileClient(
+      systemInfo, fs, computer.Object, new Mock<IProcessRunner>().Object
+    );
+
+    client.ReadJsonFile<TestJsonModel>("model.json")
+      .ShouldBe(new TestJsonModel(name: "test"));
+  }
+
+  [Fact]
+  public void ReadJsonFilesAllowsTrailingCommas() {
+    var systemInfo = new MockSystemInfo(OSType.Linux, CPUArch.X64);
+    var fs = new MockFileSystem(new Dictionary<string, MockFileData> {
+      { "model.json", new MockFileData(JSON_FILE_CONTENTS_TRAILING_COMMA) }
     });
 
     var computer = new Mock<IComputer>();

--- a/GodotEnv/src/common/clients/FileClient.cs
+++ b/GodotEnv/src/common/clients/FileClient.cs
@@ -364,7 +364,12 @@ public class FileClient : IFileClient {
     Defaults.BIN_NAME
   );
 
-  public FileClient(ISystemInfo systemInfo, IFileSystem fs, IComputer computer, IProcessRunner processRunner) {
+  public FileClient(
+    ISystemInfo systemInfo,
+    IFileSystem fs,
+    IComputer computer,
+    IProcessRunner processRunner
+  ) {
     SystemInfo = systemInfo;
     Files = fs;
     Computer = computer;
@@ -373,6 +378,7 @@ public class FileClient : IFileClient {
     JsonSerializerOptions = new JsonSerializerOptions {
       WriteIndented = true,
       ReadCommentHandling = JsonCommentHandling.Skip,
+      AllowTrailingCommas = true,
     };
   }
 

--- a/GodotEnv/src/features/addons/domain/AddonsFileRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsFileRepository.cs
@@ -5,7 +5,7 @@ using Chickensoft.GodotEnv.Common.Models;
 using Chickensoft.GodotEnv.Features.Addons.Models;
 
 public interface IAddonsFileRepository {
-  IFileClient FileClient { get; }
+  public IFileClient FileClient { get; }
 
   /// <summary>
   /// Loads the addons file in the project path and returns the filename
@@ -17,7 +17,7 @@ public interface IAddonsFileRepository {
   /// <param name="addonsFileName">Optional path to the addons file to load.
   /// If unspecified will load "addons.jsonc" or "addons.json". </param>
   /// <returns>Loaded addons file (or an empty one).</returns>
-  AddonsFile LoadAddonsFile(string projectPath, out string filename, string? addonsFileName = null);
+  public AddonsFile LoadAddonsFile(string projectPath, out string filename, string? addonsFileName = null);
 
   /// <summary>
   /// Creates an addons configuration object that represents the configuration
@@ -26,7 +26,7 @@ public interface IAddonsFileRepository {
   /// <param name="projectPath">Path containing the addons file.</param>
   /// <param name="addonsFile">Addons file.</param>
   /// <returns>Addons configuration.</returns>
-  AddonsConfiguration CreateAddonsConfiguration(
+  public AddonsConfiguration CreateAddonsConfiguration(
       string projectPath, AddonsFile addonsFile
     );
 
@@ -34,7 +34,7 @@ public interface IAddonsFileRepository {
   /// Creates a default addons file in the project path.
   /// </summary>
   /// <param name="projectPath">Project path.</param>
-  string CreateAddonsConfigurationStartingFile(string projectPath);
+  public string CreateAddonsConfigurationStartingFile(string projectPath);
 }
 
 public class AddonsFileRepository : IAddonsFileRepository {


### PR DESCRIPTION
Fixes #131. Updated `FileClient`'s `JsonSerializerOptions` to allow trailing commas, permitting them in any json files read via `FileClient.ReadJsonFile()` (e.g., `addons.jsonc` files).

Added a test to verify this functionality.