### PR TITLE
fix: use case-insensitive json for remote list

### DIFF
--- a/GodotEnv/src/features/godot/domain/GodotRepository.cs
+++ b/GodotEnv/src/features/godot/domain/GodotRepository.cs
@@ -155,6 +155,10 @@ public interface IGodotRepository {
 }
 
 public partial class GodotRepository : IGodotRepository {
+  private readonly JsonSerializerOptions _jsonOptions = new() {
+    PropertyNameCaseInsensitive = true,
+  };
+
   public ISystemInfo SystemInfo { get; }
   public Config Config { get; }
   public IFileClient FileClient { get; }
@@ -660,7 +664,7 @@ public partial class GodotRepository : IGodotRepository {
 
     var responseBody = await response.Content.ReadAsStringAsync();
     var deserializedBody =
-      JsonSerializer.Deserialize<List<RemoteVersion>>(responseBody);
+      JsonSerializer.Deserialize<List<RemoteVersion>>(responseBody, _jsonOptions);
     deserializedBody?.Reverse();
 
     var versions = new List<string>();


### PR DESCRIPTION
Fixes #155. Godot versions in the remote list have lowercase "name" element and the C# struct representing the versions has PascalCased "Name" property. This change uses case-insensitive property matching in STJ to correctly deserialize the remote values.