### PR TITLE
chore: bump Humanizer version with net8 compatibility

### DIFF
--- a/GodotEnv.Tests/reports/branch_coverage.svg
+++ b/GodotEnv.Tests/reports/branch_coverage.svg
@@ -124,7 +124,7 @@
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
         
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">56.9%</text><text class="" x="132.5" y="14">56.9%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">57%</text><text class="" x="132.5" y="14">57%</text>
         
         
     </g>

--- a/GodotEnv.Tests/reports/line_coverage.svg
+++ b/GodotEnv.Tests/reports/line_coverage.svg
@@ -123,7 +123,7 @@
 
         <text x="53" y="15" fill="#010101" fill-opacity=".3">Coverage</text>
         <text x="53" y="14" fill="#fff">Coverage</text>
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">62.4%</text><text class="" x="132.5" y="14">62.4%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">61.8%</text><text class="" x="132.5" y="14">61.8%</text>
         
         
         

--- a/GodotEnv.Tests/reports/method_coverage.svg
+++ b/GodotEnv.Tests/reports/method_coverage.svg
@@ -125,7 +125,7 @@
         <text x="53" y="14" fill="#fff">Coverage</text>
         
         
-        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">66.6%</text><text class="" x="132.5" y="14">66.6%</text>
+        <text class="" x="132.5" y="15" fill="#010101" fill-opacity=".3">66.8%</text><text class="" x="132.5" y="14">66.8%</text>
         
     </g>
 

--- a/GodotEnv/Chickensoft.GodotEnv.csproj
+++ b/GodotEnv/Chickensoft.GodotEnv.csproj
@@ -45,7 +45,7 @@
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.3.6" />
     <PackageReference Include="Downloader" Version="4.0.3" />
-    <PackageReference Include="Humanizer" Version="2.14.1" />
+    <PackageReference Include="Humanizer.Core" Version="3.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />


### PR DESCRIPTION
Bumped Humanizer dependency to v3. The Humanizer v3 metapackage requires .NET 9.0.200 or later for nuget locale parsing, so this change references Humanizer.Core. This limits us to English; any other locales will need to be referenced directly. See [the Humanizer v3 README](https://github.com/Humanizr/Humanizer/blob/7793a57045d4b893153d77a99dd1e77ef700c5cc/readme.md).

Corrects the failing tests in #190.