### PR TITLE
add a .gdignore when validating addons cache

### DIFF
--- a/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
+++ b/GodotEnv.Tests/src/features/addons/domain/AddonsRepositoryTest.cs
@@ -153,6 +153,8 @@ public class AddonsRepositoryTest
     var repo = subject.Repo;
     var client = subject.Client;
     client.Setup(c => c.DirectoryExists(CACHE_DIR)).Returns(false);
+    client.Setup(c => c.Combine(CACHE_DIR, ".gdignore")).Returns("/.addons/.gdignore");
+    client.Setup(c => c.CreateFile("/.addons/.gdignore", ""));
     repo.EnsureCacheAndAddonsDirectoriesExists();
     client.VerifyAll();
   }

--- a/GodotEnv/src/features/addons/domain/AddonsRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsRepository.cs
@@ -141,16 +141,13 @@ public class AddonsRepository(
     {
       FileClient.CreateDirectory(Config.CachePath);
     }
-    // Prevent Godot from indexing the cache with a .gdignore
-    var gdignorePath = FileClient.Combine(Config.CachePath, ".gdignore");
-    if (!FileClient.FileExists(gdignorePath))
-    {
-      FileClient.WriteAllText(gdignorePath, "");
-    }
     if (!FileClient.DirectoryExists(Config.AddonsPath))
     {
       FileClient.CreateDirectory(Config.AddonsPath);
     }
+    // Prevent Godot from indexing the cache with a .gdignore
+    var gdignorePath = FileClient.Combine(Config.CachePath, ".gdignore");
+    FileClient.CreateFile(gdignorePath, "");
   }
 
   public async Task<string> CacheAddon(

--- a/GodotEnv/src/features/addons/domain/AddonsRepository.cs
+++ b/GodotEnv/src/features/addons/domain/AddonsRepository.cs
@@ -141,6 +141,12 @@ public class AddonsRepository(
     {
       FileClient.CreateDirectory(Config.CachePath);
     }
+    // Prevent Godot from indexing the cache with a .gdignore
+    var gdignorePath = FileClient.Combine(Config.CachePath, ".gdignore");
+    if (!FileClient.FileExists(gdignorePath))
+    {
+      FileClient.WriteAllText(gdignorePath, "");
+    }
     if (!FileClient.DirectoryExists(Config.AddonsPath))
     {
       FileClient.CreateDirectory(Config.AddonsPath);


### PR DESCRIPTION
Related to #200 , I had an issue where Godot was trying to parse files in `.addons` and seeing duplicate classes to what is in `addons`.  Most users don't have this problem but including a `.gdignore` shouldn't have any negative effect.

*[Maintainer edit: fixes #200]*